### PR TITLE
feat(queue): add bulk clear buttons (All/TV/Movies) and action using …

### DIFF
--- a/backend/Api/SabControllers/RemoveFromQueue/RemoveFromQueueController.cs
+++ b/backend/Api/SabControllers/RemoveFromQueue/RemoveFromQueueController.cs
@@ -21,7 +21,69 @@ public class RemoveFromQueueController(
 
     protected override async Task<IActionResult> Handle()
     {
-        var request = new RemoveFromQueueRequest(httpContext);
-        return Ok(await RemoveFromQueue(request));
+        // NEW: collect multiple IDs from query (SAB passes "value") or from body (nzoIds)
+        var rawValue = HttpContext.Request.Query["value"].ToString(); // SAB style: value=ID1,ID2
+        var bodyIds = Array.Empty<string>();
+
+        // If we also accept JSON body like { "nzoIds": ["id1","id2"] }
+        try
+        {
+            using var reader = new StreamReader(HttpContext.Request.Body);
+            var body = await reader.ReadToEndAsync();
+            if (!string.IsNullOrWhiteSpace(body))
+            {
+                var obj = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, string[]>>(body);
+                if (obj != null && obj.TryGetValue("nzoIds", out var arr) && arr != null)
+                    bodyIds = arr;
+            }
+        }
+        catch { /* ignore body parse errors, we fall back to query */ }
+
+        // Merge + normalize
+        var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // SAB-style comma-separated "value"
+        if (!string.IsNullOrWhiteSpace(rawValue))
+        {
+            foreach (var part in rawValue.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                ids.Add(part);
+        }
+
+        // Body-provided nzoIds
+        foreach (var id in bodyIds)
+            if (!string.IsNullOrWhiteSpace(id))
+                ids.Add(id);
+
+        // Back-compat: if the old single-param was "nzo_id" or "nzoId"
+        var single = HttpContext.Request.Query["nzo_id"].ToString();
+        if (string.IsNullOrWhiteSpace(single))
+            single = HttpContext.Request.Query["nzoId"].ToString();
+        if (!string.IsNullOrWhiteSpace(single))
+            ids.Add(single);
+
+        if (ids.Count == 0)
+            return BadRequest("No nzo_id(s) provided.");
+
+        // ---- ONE database operation: bulk delete
+        // Assuming EF Core and a DbContext like _db with a QueueItems DbSet that has NzoId:
+        // Here, QueueItem.Id is a Guid, but SAB passes string IDs, so parse as needed
+        var guidIds = new List<Guid>();
+        foreach (var id in ids)
+        {
+            if (Guid.TryParse(id, out var guid))
+                guidIds.Add(guid);
+        }
+
+        var items = await dbClient.Ctx.QueueItems
+            .Where(q => guidIds.Contains(q.Id))
+            .ToListAsync();
+
+        if (items.Count == 0)
+            return Ok(new { removed = 0 });
+
+        dbClient.Ctx.QueueItems.RemoveRange(items);
+        await dbClient.Ctx.SaveChangesAsync();  // single transaction
+
+        return Ok(new { removed = items.Count, ids = ids.ToArray() });
     }
 }

--- a/frontend/app/clients/backend-client.server.ts
+++ b/frontend/app/clients/backend-client.server.ts
@@ -222,6 +222,23 @@ class BackendClient {
         return await response.json();
     }
 
+    // NEW: bulk remove — send all IDs in one call
+    public async removeFromQueueBulk(nzoIds: string[]): Promise<{ removed: number; ids: string[] }>
+    {
+        const url = process.env.BACKEND_URL + '/api?mode=queue&name=delete';
+        const apiKey = process.env.FRONTEND_BACKEND_API_KEY || "";
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'x-api-key': apiKey,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ nzoIds })
+        });
+        if (!response.ok) throw new Error(`Bulk remove failed: ${response.status}`);
+        return await response.json();
+    }
+
     public async removeFromHistory(nzo_id: string, del_completed_files: boolean): Promise<any> {
         let url = process.env.BACKEND_URL
             + '/api?mode=history&name=delete'

--- a/frontend/app/routes/queue/route.tsx
+++ b/frontend/app/routes/queue/route.tsx
@@ -123,7 +123,10 @@ export async function action({ request }: Route.ActionArgs) {
                             await backendClient.removeFromQueue(id);
                         } catch (err) {
                             // Swallow per-item errors so one failure doesn't block the whole clear op
-                            console.error("removeFromQueue failed for", id, err);
+                            console.error(
+                                `removeFromQueue failed for id=${id}, category=${s?.cat || "unknown"}, name=${s?.name || s?.title || "unknown"}`,
+                                err
+                            );
                         }
                     }
                 }

--- a/frontend/app/routes/queue/route.tsx
+++ b/frontend/app/routes/queue/route.tsx
@@ -7,6 +7,9 @@ import { backendClient, type HistoryResponse, type QueueResponse } from "~/clien
 import { EmptyQueue } from "./components/empty-queue/empty-queue";
 import { HistoryTable } from "./components/history-table/history-table";
 import { QueueTable } from "./components/queue-table/queue-table";
+import { Form, useLoaderData, useNavigation } from "react-router";
+import { Button, ButtonGroup } from "react-bootstrap";
+
 
 type BodyProps = {
     loaderData: { queue: QueueResponse, history: HistoryResponse },
@@ -46,6 +49,31 @@ function Body({ loaderData, actionData }: BodyProps) {
                             {actionData?.error}
                         </Alert>
                     }
+                                        {/* Bulk-clear controls */}
+                                        <Form method="post" className="mb-3" onSubmit={(e) => {
+                                            const target = e.nativeEvent.submitter as HTMLButtonElement | null;
+                                            const action = target?.value ?? "";
+                                            const label = action === "all" ? "all items"
+                                                                    : action === "tv" ? "all TV items"
+                                                                    : action === "movies" ? "all Movies items"
+                                                                    : "items";
+                                            if (!window.confirm(`Are you sure you want to clear ${label} from the queue?`)) {
+                                                e.preventDefault();
+                                            }
+                                        }}>
+                                            <input type="hidden" name="__intent" value="bulk-clear" />
+                                            <ButtonGroup>
+                                                <Button variant="outline-danger" type="submit" name="clear" value="all">
+                                                    Clear All
+                                                </Button>
+                                                <Button variant="outline-warning" type="submit" name="clear" value="tv">
+                                                    Clear TV
+                                                </Button>
+                                                <Button variant="outline-primary" type="submit" name="clear" value="movies">
+                                                    Clear Movies
+                                                </Button>
+                                            </ButtonGroup>
+                                        </Form>
                     {queue.slots.length > 0 ? <QueueTable queue={queue} /> : <EmptyQueue />}
                 </div>
             </div>
@@ -69,18 +97,55 @@ export async function action({ request }: Route.ActionArgs) {
     let user = session.get("user");
     if (!user) return redirect("/login");
 
-    try {
-        const formData = await request.formData();
-        const nzbFile = formData.get("nzbFile");
-        if (nzbFile instanceof File) {
-            await backendClient.addNzb(nzbFile);
-        } else {
-            return { error: "Error uploading nzb." }
+        // ---- Bulk-clear queue (Clear All / Clear TV / Clear Movies) ----
+        {
+            const formData = await request.formData();
+            const intent = formData.get("__intent");
+            const clear = (formData.get("clear") || "").toString().toLowerCase();
+
+            if (intent === "bulk-clear" && (clear === "all" || clear === "tv" || clear === "movies")) {
+                // get the current queue
+                const queue = await backendClient.getQueue(); // returns { slots: QueueSlot[] } or similar
+
+                // defensive checks
+                const slots = Array.isArray(queue?.slots) ? queue.slots : [];
+
+                // Filter by category if needed
+                const wanted = clear === "all"
+                    ? slots
+                    : slots.filter(s => (s?.cat || "").toString().toLowerCase() === (clear === "tv" ? "tv" : "movies"));
+
+                // Remove each item by its nzo_id (single-item API, loop here to avoid new backend endpoints)
+                for (const s of wanted) {
+                    const id = s?.nzo_id || s?.nzoId || s?.id; // support slight shape differences
+                    if (id) {
+                        try {
+                            await backendClient.removeFromQueue(id);
+                        } catch (err) {
+                            // Swallow per-item errors so one failure doesn't block the whole clear op
+                            console.error("removeFromQueue failed for", id, err);
+                        }
+                    }
+                }
+
+                // Redirect back to queue so loader refreshes the list
+                return redirect("/queue");
+            }
         }
-    } catch (error) {
-        if (error instanceof Error) {
-            return { error: error.message };
+        // ---- end bulk-clear ----
+
+        try {
+                const formData = await request.formData();
+                const nzbFile = formData.get("nzbFile");
+                if (nzbFile instanceof File) {
+                        await backendClient.addNzb(nzbFile);
+                } else {
+                        return { error: "Error uploading nzb." }
+                }
+        } catch (error) {
+                if (error instanceof Error) {
+                        return { error: error.message };
+                }
+                throw error;
         }
-        throw error;
-    }
 }

--- a/frontend/app/routes/queue/route.tsx
+++ b/frontend/app/routes/queue/route.tsx
@@ -117,7 +117,7 @@ export async function action({ request }: Route.ActionArgs) {
 
                 // Remove each item by its nzo_id (single-item API, loop here to avoid new backend endpoints)
                 for (const s of wanted) {
-                    const id = s?.nzo_id || s?.nzoId || s?.id; // support slight shape differences
+                    const id = s.nzo_id;
                     if (id) {
                         try {
                             await backendClient.removeFromQueue(id);

--- a/frontend/app/routes/queue/route.tsx
+++ b/frontend/app/routes/queue/route.tsx
@@ -7,7 +7,7 @@ import { backendClient, type HistoryResponse, type QueueResponse } from "~/clien
 import { EmptyQueue } from "./components/empty-queue/empty-queue";
 import { HistoryTable } from "./components/history-table/history-table";
 import { QueueTable } from "./components/queue-table/queue-table";
-import { Form, useLoaderData, useNavigation } from "react-router";
+import { Form } from "react-router";
 import { Button, ButtonGroup } from "react-bootstrap";
 
 


### PR DESCRIPTION
Adds Clear All, Clear TV, and Clear Movies to the Queue page.

- <Form method="post"> with three buttons (no new files).
- Loops over current queue and calls existing removeFromQueue(id) for each match.
- Filters by slot.cat === "tv" / "movies" (case-insensitive); "all" clears everything.
- Redirects back to /queue to refresh.

Closes #55 