### PR TITLE
Use Usenet.Custom library instead of Usenet

### DIFF
--- a/backend/NzbWebDAV.csproj
+++ b/backend/NzbWebDAV.csproj
@@ -18,7 +18,7 @@
       <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.0.1-dev-00953" />
       <PackageReference Include="SharpCompress" Version="0.39.0" />
-      <PackageReference Include="Usenet" Version="3.1.0" />
+      <PackageReference Include="Usenet.Custom" Version="3.1.1-nzbdav" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This uses Usenet.Custom from https://github.com/pannal/Usenet which adds:
- Allow ignoring all RemoteCertificateNameMismatch by supplying the environment variable NZBDAV_NNTP_TLS_IGNORE_NAME_MISMATCH=true
- Allow ignoring specific RemoteCertificateNameMismatch by supplying the environment variable NZBDAV_NNTP_TLS_IGNORE_HOSTS=host1[,;]host2[,;]..

I think this whole project should switch to https://github.com/Spottarr/Usenet, though!