### PR TITLE
Add support for Infuse WebDAV

### DIFF
--- a/backend/WebDav/Base/BaseStoreCollectionPropertyManager.cs
+++ b/backend/WebDav/Base/BaseStoreCollectionPropertyManager.cs
@@ -1,10 +1,11 @@
 using System.Xml.Linq;
 using NWebDav.Server;
 using NWebDav.Server.Props;
+using NWebDav.Server.Stores;
 
 namespace NzbWebDAV.WebDav.Base;
 
-internal class DavIsCollection : DavString<BaseStoreCollection>
+internal class DavIsCollection<T> : DavString<T> where T : IStoreItem
 {
     public static readonly XName PropertyName = WebDavNamespaces.DavNs + "iscollection";
     public override XName Name => PropertyName;
@@ -44,7 +45,7 @@ public class BaseStoreCollectionPropertyManager() : PropertyManager<BaseStoreCol
         {
             Getter = _ => 0
         },
-        new DavIsCollection
+        new DavIsCollection<BaseStoreCollection>
         {
             Getter = _ => "1"
         }

--- a/backend/WebDav/Base/BaseStoreItemPropertyManager.cs
+++ b/backend/WebDav/Base/BaseStoreItemPropertyManager.cs
@@ -5,12 +5,6 @@ using NWebDav.Server.Props;
 
 namespace NzbWebDAV.WebDav.Base;
 
-internal class DavIsCollectionItem : DavString<BaseStoreItem>
-{
-    public static readonly XName PropertyName = WebDavNamespaces.DavNs + "iscollection";
-    public override XName Name => PropertyName;
-}
-
 public class BaseStoreItemPropertyManager() : PropertyManager<BaseStoreItem>(DavProperties)
 {
     private static readonly FileExtensionContentTypeProvider MimeTypeProvider = new();
@@ -44,7 +38,7 @@ public class BaseStoreItemPropertyManager() : PropertyManager<BaseStoreItem>(Dav
         {
             Getter = _ => [DavResourceType]
         },
-        new DavIsCollectionItem
+        new DavIsCollection<BaseStoreItem>
         {
             Getter = _ => "0"
         }


### PR DESCRIPTION
This PR adds props to collections and items to allow the media player Infuse to correctly recognize WebDAV folders and content.

Refer to #182 for discussion of the topic.