### PR TITLE
Refactor: Empty string handling as extension

### DIFF
--- a/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
+++ b/backend/Api/SabControllers/AddUrl/AddUrlRequest.cs
@@ -104,7 +104,7 @@ public class AddUrlRequest() : AddFileRequest
             MaxAutomaticRedirections = MaxAutomaticRedirections,
         };
         var httpClient = new HttpClient(handler);
-        var userAgent = EnvironmentUtil.GetEnvironmentVariable("NZB_GRAB_USER_AGENT") ?? DefaultUserAgent;
+        var userAgent = EnvironmentUtil.GetVariable("NZB_GRAB_USER_AGENT") ?? DefaultUserAgent;
         httpClient.DefaultRequestHeaders.Add("User-Agent", userAgent);
         return httpClient;
     }
@@ -113,7 +113,7 @@ public class AddUrlRequest() : AddFileRequest
     {
         var contentDisposition = response.Content.Headers.ContentDisposition;
         var filename = contentDisposition?.FileName?.Trim('"');
-        return StringUtil.EmptyToNull(filename);
+        return filename.ToNullIfEmpty();
     }
 
     private static string? GetFilenameFromUrl(string url)

--- a/backend/Config/ConfigManager.cs
+++ b/backend/Config/ConfigManager.cs
@@ -3,13 +3,14 @@ using Microsoft.EntityFrameworkCore;
 using NzbWebDAV.Clients.Usenet.Concurrency;
 using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
+using NzbWebDAV.Extensions;
 using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Config;
 
 public class ConfigManager
 {
-    public static readonly string AppVersion = EnvironmentUtil.GetEnvironmentVariable("NZBDAV_VERSION") ?? "unknown";
+    public static readonly string AppVersion = EnvironmentUtil.GetVariable("NZBDAV_VERSION") ?? "unknown";
 
     private readonly Dictionary<string, string> _config = new();
     public event EventHandler<ConfigEventArgs>? OnConfigChanged;
@@ -32,13 +33,13 @@ public class ConfigManager
     {
         lock (_config)
         {
-            return _config.TryGetValue(configName, out string? value) ? value : null;
+            return _config.TryGetValue(configName, out string? value) ? value.ToNullIfEmpty() : null;
         }
     }
 
     private T? GetConfigValue<T>(string configName)
     {
-        var rawValue = StringUtil.EmptyToNull(GetConfigValue(configName));
+        var rawValue = GetConfigValue(configName);
         return rawValue == null ? default : JsonSerializer.Deserialize<T>(rawValue);
     }
 
@@ -58,8 +59,8 @@ public class ConfigManager
 
     public string GetRcloneMountDir()
     {
-        var mountDir = StringUtil.EmptyToNull(GetConfigValue("rclone.mount-dir"))
-                       ?? EnvironmentUtil.GetEnvironmentVariable("MOUNT_DIR")
+        var mountDir = GetConfigValue("rclone.mount-dir")
+                       ?? EnvironmentUtil.GetVariable("MOUNT_DIR")
                        ?? "/mnt/nzbdav";
         if (mountDir.EndsWith('/')) mountDir = mountDir.TrimEnd('/');
         return mountDir;
@@ -67,7 +68,7 @@ public class ConfigManager
 
     public string GetApiKey()
     {
-        return StringUtil.EmptyToNull(GetConfigValue("api.key"))
+        return GetConfigValue("api.key")
                ?? EnvironmentUtil.GetRequiredVariable("FRONTEND_BACKEND_API_KEY");
     }
 
@@ -79,29 +80,29 @@ public class ConfigManager
 
     public string GetApiCategories()
     {
-        return StringUtil.EmptyToNull(GetConfigValue("api.categories"))
-               ?? EnvironmentUtil.GetEnvironmentVariable("CATEGORIES")
+        return GetConfigValue("api.categories")
+               ?? EnvironmentUtil.GetVariable("CATEGORIES")
                ?? "audio,software,tv,movies";
     }
 
     public string GetManualUploadCategory()
     {
-        return StringUtil.EmptyToNull(GetConfigValue("api.manual-category"))
+        return GetConfigValue("api.manual-category")
                ?? "uncategorized";
     }
 
     public string? GetWebdavUser()
     {
-        return StringUtil.EmptyToNull(GetConfigValue("webdav.user"))
-               ?? EnvironmentUtil.GetEnvironmentVariable("WEBDAV_USER")
+        return GetConfigValue("webdav.user")
+               ?? EnvironmentUtil.GetVariable("WEBDAV_USER")
                ?? "admin";
     }
 
     public string? GetWebdavPasswordHash()
     {
-        var hashedPass = StringUtil.EmptyToNull(GetConfigValue("webdav.pass"));
+        var hashedPass = GetConfigValue("webdav.pass");
         if (hashedPass != null) return hashedPass;
-        var pass = EnvironmentUtil.GetEnvironmentVariable("WEBDAV_PASSWORD");
+        var pass = EnvironmentUtil.GetVariable("WEBDAV_PASSWORD");
         if (pass != null) return PasswordUtil.Hash(pass);
         return null;
     }
@@ -109,26 +110,26 @@ public class ConfigManager
     public bool IsEnsureImportableVideoEnabled()
     {
         var defaultValue = true;
-        var configValue = StringUtil.EmptyToNull(GetConfigValue("api.ensure-importable-video"));
+        var configValue = GetConfigValue("api.ensure-importable-video");
         return (configValue != null ? bool.Parse(configValue) : defaultValue);
     }
 
     public bool ShowHiddenWebdavFiles()
     {
         var defaultValue = false;
-        var configValue = StringUtil.EmptyToNull(GetConfigValue("webdav.show-hidden-files"));
+        var configValue = GetConfigValue("webdav.show-hidden-files");
         return (configValue != null ? bool.Parse(configValue) : defaultValue);
     }
 
     public string? GetLibraryDir()
     {
-        return StringUtil.EmptyToNull(GetConfigValue("media.library-dir"));
+        return GetConfigValue("media.library-dir");
     }
 
     public int GetMaxDownloadConnections()
     {
         return int.Parse(
-            StringUtil.EmptyToNull(GetConfigValue("usenet.max-download-connections"))
+            GetConfigValue("usenet.max-download-connections")
             ?? Math.Min(GetUsenetProviderConfig().TotalPooledConnections, 15).ToString()
         );
     }
@@ -136,14 +137,14 @@ public class ConfigManager
     public int GetArticleBufferSize()
     {
         return int.Parse(
-            StringUtil.EmptyToNull(GetConfigValue("usenet.article-buffer-size"))
+            GetConfigValue("usenet.article-buffer-size")
             ?? "40"
         );
     }
 
     public SemaphorePriorityOdds GetStreamingPriority()
     {
-        var stringValue = StringUtil.EmptyToNull(GetConfigValue("usenet.streaming-priority"));
+        var stringValue = GetConfigValue("usenet.streaming-priority");
         var numericalValue = int.Parse(stringValue ?? "80");
         return new SemaphorePriorityOdds() { HighPriorityOdds = numericalValue };
     }
@@ -151,7 +152,7 @@ public class ConfigManager
     public bool IsEnforceReadonlyWebdavEnabled()
     {
         var defaultValue = true;
-        var configValue = StringUtil.EmptyToNull(GetConfigValue("webdav.enforce-readonly"));
+        var configValue = GetConfigValue("webdav.enforce-readonly");
         return (configValue != null ? bool.Parse(configValue) : defaultValue);
     }
 
@@ -168,21 +169,21 @@ public class ConfigManager
     public bool IsPreviewPar2FilesEnabled()
     {
         var defaultValue = false;
-        var configValue = StringUtil.EmptyToNull(GetConfigValue("webdav.preview-par2-files"));
+        var configValue = GetConfigValue("webdav.preview-par2-files");
         return (configValue != null ? bool.Parse(configValue) : defaultValue);
     }
 
     public bool IsIgnoreSabHistoryLimitEnabled()
     {
         var defaultValue = true;
-        var configValue = StringUtil.EmptyToNull(GetConfigValue("api.ignore-history-limit"));
+        var configValue = GetConfigValue("api.ignore-history-limit");
         return (configValue != null ? bool.Parse(configValue) : defaultValue);
     }
 
     public bool IsRepairJobEnabled()
     {
         var defaultValue = false;
-        var configValue = StringUtil.EmptyToNull(GetConfigValue("repair.enable"));
+        var configValue = GetConfigValue("repair.enable");
         var isRepairJobEnabled = (configValue != null ? bool.Parse(configValue) : defaultValue);
         return isRepairJobEnabled
                && GetLibraryDir() != null

--- a/backend/Database/DavDatabaseContext.cs
+++ b/backend/Database/DavDatabaseContext.cs
@@ -9,7 +9,7 @@ namespace NzbWebDAV.Database;
 
 public sealed class DavDatabaseContext() : DbContext(Options.Value)
 {
-    public static string ConfigPath => EnvironmentUtil.GetEnvironmentVariable("CONFIG_PATH") ?? "/config";
+    public static string ConfigPath => EnvironmentUtil.GetVariable("CONFIG_PATH") ?? "/config";
     public static string DatabaseFilePath => Path.Join(ConfigPath, "db.sqlite");
 
     private static readonly Lazy<DbContextOptions<DavDatabaseContext>> Options = new(

--- a/backend/Extensions/HttpContextExtensions.cs
+++ b/backend/Extensions/HttpContextExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using NzbWebDAV.Utils;
 
 namespace NzbWebDAV.Extensions;
 
@@ -6,7 +7,7 @@ public static class HttpContextExtensions
 {
     public static string? GetQueryParam(this HttpContext httpContext, string name)
     {
-        return httpContext.Request.Query[name].FirstOrDefault();
+        return httpContext.Request.Query[name].FirstOrDefault().ToNullIfEmpty();
     }
 
     public static IEnumerable<string> GetQueryParamValues(this HttpContext httpContext, string name)

--- a/backend/Extensions/StringExtensions.cs
+++ b/backend/Extensions/StringExtensions.cs
@@ -11,4 +11,9 @@ public static class StringExtensions
     {
         return value.StartsWith(prefix) ? value[prefix.Length..] : value;
     }
+
+    extension(string? str)
+    {
+        public string? ToNullIfEmpty() => str == "" ? null : str;
+    }
 }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -36,7 +36,7 @@ class Program
 
         // Initialize logger
         var defaultLevel = LogEventLevel.Information;
-        var envLevel = EnvironmentUtil.GetEnvironmentVariable("LOG_LEVEL");
+        var envLevel = EnvironmentUtil.GetVariable("LOG_LEVEL");
         var level = Enum.TryParse<LogEventLevel>(envLevel, true, out var parsed) ? parsed : defaultLevel;
         Log.Logger = new LoggerConfiguration()
             .MinimumLevel.Is(level)

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -162,7 +162,7 @@ public class HealthCheckService : BackgroundService
 
     private async Task UpdateReleaseDate(DavItem davItem, List<string> segments, CancellationToken ct)
     {
-        var firstSegmentId = StringUtil.EmptyToNull(segments.FirstOrDefault());
+        var firstSegmentId = segments.FirstOrDefault().ToNullIfEmpty();
         if (firstSegmentId == null) return;
         var articleHeadersResponse = await _usenetClient.HeadAsync(firstSegmentId, ct).ConfigureAwait(false);
         var articleHeaders = articleHeadersResponse.ArticleHeaders!;

--- a/backend/Utils/EnvironmentUtil.cs
+++ b/backend/Utils/EnvironmentUtil.cs
@@ -1,15 +1,17 @@
-﻿namespace NzbWebDAV.Utils;
+﻿using NzbWebDAV.Extensions;
+
+namespace NzbWebDAV.Utils;
 
 public static class EnvironmentUtil
 {
-    public static string? GetEnvironmentVariable(string envVariable)
+    public static string? GetVariable(string envVariable)
     {
-        return StringUtil.EmptyToNull(Environment.GetEnvironmentVariable(envVariable));
+        return Environment.GetEnvironmentVariable(envVariable).ToNullIfEmpty();
     }
 
     public static string GetRequiredVariable(string envVariable)
     {
-        return Environment.GetEnvironmentVariable(envVariable) ??
+        return GetVariable(envVariable) ??
                throw new Exception($"The environment variable `{envVariable}` must be set.");
     }
 

--- a/backend/Utils/StringUtil.cs
+++ b/backend/Utils/StringUtil.cs
@@ -1,9 +1,0 @@
-﻿namespace NzbWebDAV.Utils;
-
-public static class StringUtil
-{
-    public static string? EmptyToNull(string? value)
-    {
-        return string.IsNullOrWhiteSpace(value) ? null : value;
-    }
-}


### PR DESCRIPTION
Split refactoring part from #216

-----

- The current implementation is more error prone and verbose.
- The refactor is a bit more polished, safe and has less boilerplate.
- The refactor is explicit in casting the type string to null if empty.

-----

> * While I appreciate the refactor, I personally think `StringUtil.EmptyToNull(...)` is a little more clear on what it does versus the `.OrNull()` extension.

One last try. :)
I renamed it to `ToNullIfEmpty()`, as it casts to `null`. This is more clear and the `To` part  indicates the type change.
  
> * And I'm generally a fan of extension methods :) The repo is [full of them](https://github.com/nzbdav-dev/nzbdav/tree/0d2b675b62ab7fb26e19cc4dc42be0e3d38516ac/backend/Extensions).

You are right, I missed that.. I moved the extension into the existing `StringExtensions.cs`.

-----

Disclaimer: No AI was used in this pull request.