### PR TITLE
Fix: Allow special characters for filename-passwords

### DIFF
--- a/backend/Utils/FilenameUtil.cs
+++ b/backend/Utils/FilenameUtil.cs
@@ -7,7 +7,8 @@ public partial class FilenameUtil
     // Group `pw` contains the password,
     // Group `rm` contains the part of the filename that should be removed to create a clean job name
     // Group `br` ensures that the brackets are closed / is used for back reference
-    [GeneratedRegex(@"(?<rm>[\s-]*(?:(?<br>{{)|password=)(?<pw>\w+)(?(br)}}))\.nzb$", RegexOptions.IgnoreCase)]
+    // Tests: https://regex101.com/r/qsIcnE/1
+    [GeneratedRegex(@"(?<rm>[\s-]*(?:(?<br>{{)|password=)(?<pw>.+)(?(br)}}))\.nzb$", RegexOptions.IgnoreCase)]
     public static partial Regex PasswordRegex { get; }
 
     private static readonly HashSet<string> VideoExtensions =


### PR DESCRIPTION
Fixes #307 

I just replaced `\w` with `.`.

Added some tests on regex101:
https://regex101.com/r/qsIcnE/1

Disclaimer: No AI was used in this pull request.