### PR TITLE
Handle duplicate NZB segments with fallback

### DIFF
--- a/backend.Tests/Clients/Usenet/DuplicateSegmentFallbackTests.cs
+++ b/backend.Tests/Clients/Usenet/DuplicateSegmentFallbackTests.cs
@@ -1,0 +1,61 @@
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Models.Nzb;
+using NzbWebDAV.Tests.TestDoubles;
+
+namespace NzbWebDAV.Tests.Clients.Usenet;
+
+public class DuplicateSegmentFallbackTests
+{
+    [Fact]
+    public async Task CheckAllSegmentsAsyncAcceptsAnyAvailableDuplicateCandidate()
+    {
+        using var client = new FakeNntpClient()
+            .AddSegment("segment-1b", [1, 2, 3])
+            .AddSegment("segment-2", [4, 5, 6]);
+
+        await client.CheckAllSegmentsAsync(
+            [NzbSegmentIdSet.Encode(["segment-1a", "segment-1b"]), "segment-2"],
+            concurrency: 2,
+            progress: null,
+            CancellationToken.None
+        );
+
+        Assert.Equal(3, client.StatCallCount);
+    }
+
+    [Fact]
+    public async Task GetFileStreamFallsBackToAlternateDuplicateSegment()
+    {
+        using var client = new FakeNntpClient()
+            .AddSegment("segment-1b", [1, 2, 3], partOffset: 0)
+            .AddSegment("segment-2", [4, 5], partOffset: 3);
+        var nzbFile = new NzbFile
+        {
+            Subject = "example.mkv"
+        };
+        nzbFile.Segments.Add(new NzbSegment { Number = 1, Bytes = 3, MessageId = "segment-1a" });
+        nzbFile.Segments.Add(new NzbSegment { Number = 1, Bytes = 3, MessageId = "segment-1b" });
+        nzbFile.Segments.Add(new NzbSegment { Number = 2, Bytes = 2, MessageId = "segment-2" });
+
+        await using var stream = await client.GetFileStream(nzbFile, articleBufferSize: 0, CancellationToken.None);
+        var bytes = new byte[5];
+        await stream.ReadExactlyAsync(bytes);
+
+        Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, bytes);
+    }
+
+    [Fact]
+    public async Task CheckAllSegmentsAsyncThrowsWhenAllDuplicateCandidatesAreMissing()
+    {
+        using var client = new FakeNntpClient();
+
+        var exception = await Assert.ThrowsAsync<UsenetArticleNotFoundException>(() => client.CheckAllSegmentsAsync(
+            [NzbSegmentIdSet.Encode(["segment-1a", "segment-1b"])],
+            concurrency: 1,
+            progress: null,
+            CancellationToken.None
+        ));
+
+        Assert.Equal("segment-1b", exception.SegmentId);
+    }
+}

--- a/backend.Tests/GlobalUsings.cs
+++ b/backend.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/backend.Tests/Models/Nzb/NzbDocumentTests.cs
+++ b/backend.Tests/Models/Nzb/NzbDocumentTests.cs
@@ -1,0 +1,35 @@
+using System.Text;
+using NzbWebDAV.Models.Nzb;
+
+namespace NzbWebDAV.Tests.Models.Nzb;
+
+public class NzbDocumentTests
+{
+    [Fact]
+    public async Task DuplicateSegmentNumbersCollapseIntoOneLogicalSegmentWithAlternates()
+    {
+        const string xml = """
+                           <?xml version="1.0" encoding="utf-8"?>
+                           <nzb>
+                             <file subject="example.mkv">
+                               <segments>
+                                 <segment bytes="10" number="1">segment-a</segment>
+                                 <segment bytes="11" number="1">segment-b</segment>
+                                 <segment bytes="20" number="2">segment-c</segment>
+                               </segments>
+                             </file>
+                           </nzb>
+                           """;
+
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+        var document = await NzbDocument.LoadAsync(stream);
+        var file = Assert.Single(document.Files);
+
+        Assert.Equal(2, file.GetLogicalSegmentCount());
+        Assert.Equal(30, file.GetTotalYencodedSize());
+
+        var segmentIds = file.GetSegmentIds();
+        Assert.Equal(["segment-a", "segment-b"], NzbSegmentIdSet.Decode(segmentIds[0]));
+        Assert.Equal(["segment-c"], NzbSegmentIdSet.Decode(segmentIds[1]));
+    }
+}

--- a/backend.Tests/TestDoubles/FakeNntpClient.cs
+++ b/backend.Tests/TestDoubles/FakeNntpClient.cs
@@ -1,0 +1,240 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using NzbWebDAV.Clients.Usenet;
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Streams;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Tests.TestDoubles;
+
+public sealed class FakeNntpClient : NntpClient
+{
+    private sealed class TrackingMemoryStream(byte[] buffer, Action onDispose) : MemoryStream(buffer, writable: false)
+    {
+        private readonly Action _onDispose = onDispose;
+        private bool _disposed;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!_disposed && disposing)
+            {
+                _onDispose();
+                _disposed = true;
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public override ValueTask DisposeAsync()
+        {
+            if (!_disposed)
+            {
+                _onDispose();
+                _disposed = true;
+            }
+
+            return base.DisposeAsync();
+        }
+    }
+
+    private sealed record SegmentData(
+        byte[] Bytes,
+        long PartOffset,
+        UsenetYencHeader YencHeader,
+        UsenetArticleHeader ArticleHeaders
+    );
+
+    private readonly ConcurrentDictionary<string, SegmentData> _segments = new(StringComparer.Ordinal);
+
+    private int _getYencHeadersCallCount;
+    private int _decodedBodyCallCount;
+    private int _decodedArticleCallCount;
+    private int _headCallCount;
+    private int _statCallCount;
+
+    public int GetYencHeadersCallCount => Volatile.Read(ref _getYencHeadersCallCount);
+    public int DecodedBodyCallCount => Volatile.Read(ref _decodedBodyCallCount);
+    public int DecodedArticleCallCount => Volatile.Read(ref _decodedArticleCallCount);
+    public int HeadCallCount => Volatile.Read(ref _headCallCount);
+    public int StatCallCount => Volatile.Read(ref _statCallCount);
+
+    public FakeNntpClient AddSegment(string segmentId, byte[] bytes, long partOffset = 0)
+    {
+        var header = CreateYencHeader(partOffset, bytes.Length);
+        var articleHeaders = CreateArticleHeader(segmentId);
+        _segments[segmentId] = new SegmentData(bytes, partOffset, header, articleHeaders);
+        return this;
+    }
+
+    public override Task ConnectAsync(string host, int port, bool useSsl, CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    public override Task<UsenetResponse> AuthenticateAsync(string user, string pass, CancellationToken cancellationToken)
+    {
+        return Task.FromException<UsenetResponse>(new NotSupportedException());
+    }
+
+    public override Task<UsenetStatResponse> StatAsync(SegmentId segmentId, CancellationToken cancellationToken)
+    {
+        Interlocked.Increment(ref _statCallCount);
+        _ = GetSegment(segmentId);
+        return Task.FromResult(new UsenetStatResponse
+        {
+            ArticleExists = true,
+            ResponseCode = (int)UsenetResponseType.ArticleExists,
+            ResponseMessage = "223 - Article exists"
+        });
+    }
+
+    public override Task<UsenetHeadResponse> HeadAsync(SegmentId segmentId, CancellationToken cancellationToken)
+    {
+        Interlocked.Increment(ref _headCallCount);
+        var data = GetSegment(segmentId);
+        return Task.FromResult(new UsenetHeadResponse
+        {
+            SegmentId = segmentId,
+            ResponseCode = (int)UsenetResponseType.ArticleRetrievedHeadFollows,
+            ResponseMessage = "221 - Head retrieved",
+            ArticleHeaders = data.ArticleHeaders
+        });
+    }
+
+    public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(SegmentId segmentId, CancellationToken cancellationToken)
+    {
+        return DecodedBodyAsync(segmentId, onConnectionReadyAgain: null, cancellationToken);
+    }
+
+    public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+        SegmentId segmentId,
+        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        CancellationToken cancellationToken
+    )
+    {
+        Interlocked.Increment(ref _decodedBodyCallCount);
+        onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+        return Task.FromResult(CreateBodyResponse(segmentId));
+    }
+
+    public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+        SegmentId segmentId,
+        CancellationToken cancellationToken
+    )
+    {
+        return DecodedArticleAsync(segmentId, onConnectionReadyAgain: null, cancellationToken);
+    }
+
+    public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+        SegmentId segmentId,
+        Action<ArticleBodyResult>? onConnectionReadyAgain,
+        CancellationToken cancellationToken
+    )
+    {
+        Interlocked.Increment(ref _decodedArticleCallCount);
+        var data = GetSegment(segmentId);
+        onConnectionReadyAgain?.Invoke(ArticleBodyResult.Retrieved);
+        return Task.FromResult(new UsenetDecodedArticleResponse
+        {
+            SegmentId = segmentId,
+            ResponseCode = (int)UsenetResponseType.ArticleRetrievedHeadAndBodyFollow,
+            ResponseMessage = "220 - Article retrieved",
+            ArticleHeaders = data.ArticleHeaders,
+            Stream = CreateBodyStream(segmentId, data)
+        });
+    }
+
+    public override Task<UsenetDateResponse> DateAsync(CancellationToken cancellationToken)
+    {
+        return Task.FromException<UsenetDateResponse>(new NotSupportedException());
+    }
+
+    public override Task<UsenetExclusiveConnection> AcquireExclusiveConnectionAsync(
+        string segmentId,
+        CancellationToken cancellationToken
+    )
+    {
+        return Task.FromResult(new UsenetExclusiveConnection(onConnectionReadyAgain: null));
+    }
+
+    public override Task<UsenetDecodedBodyResponse> DecodedBodyAsync(
+        SegmentId segmentId,
+        UsenetExclusiveConnection exclusiveConnection,
+        CancellationToken cancellationToken
+    )
+    {
+        return DecodedBodyAsync(segmentId, exclusiveConnection.OnConnectionReadyAgain, cancellationToken);
+    }
+
+    public override Task<UsenetDecodedArticleResponse> DecodedArticleAsync(
+        SegmentId segmentId,
+        UsenetExclusiveConnection exclusiveConnection,
+        CancellationToken cancellationToken
+    )
+    {
+        return DecodedArticleAsync(segmentId, exclusiveConnection.OnConnectionReadyAgain, cancellationToken);
+    }
+
+    public override Task<UsenetYencHeader> GetYencHeadersAsync(string segmentId, CancellationToken ct)
+    {
+        Interlocked.Increment(ref _getYencHeadersCallCount);
+        return Task.FromResult(GetSegment(segmentId).YencHeader);
+    }
+
+    public override void Dispose()
+    {
+        GC.SuppressFinalize(this);
+    }
+
+    private UsenetDecodedBodyResponse CreateBodyResponse(string segmentId)
+    {
+        var data = GetSegment(segmentId);
+        return new UsenetDecodedBodyResponse
+        {
+            SegmentId = segmentId,
+            ResponseCode = (int)UsenetResponseType.ArticleRetrievedBodyFollows,
+            ResponseMessage = "222 - Body retrieved",
+            Stream = CreateBodyStream(segmentId, data)
+        };
+    }
+
+    private CachedYencStream CreateBodyStream(string segmentId, SegmentData data)
+    {
+        var stream = new TrackingMemoryStream(data.Bytes, () => { });
+        return new CachedYencStream(data.YencHeader, stream);
+    }
+
+    private SegmentData GetSegment(string segmentId)
+    {
+        if (_segments.TryGetValue(segmentId, out var data))
+            return data;
+
+        throw new UsenetArticleNotFoundException(segmentId);
+    }
+
+    private static UsenetYencHeader CreateYencHeader(long partOffset, long partSize)
+    {
+        return new UsenetYencHeader
+        {
+            FileName = "segment.bin",
+            FileSize = partOffset + partSize,
+            LineLength = 128,
+            PartNumber = 1,
+            TotalParts = 1,
+            PartSize = partSize,
+            PartOffset = partOffset
+        };
+    }
+
+    private static UsenetArticleHeader CreateArticleHeader(string segmentId)
+    {
+        return new UsenetArticleHeader
+        {
+            Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Subject"] = segmentId
+            }
+        };
+    }
+}

--- a/backend.Tests/backend.Tests.csproj
+++ b/backend.Tests/backend.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\backend\NzbWebDAV.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/backend/Clients/Usenet/NntpClient.cs
+++ b/backend/Clients/Usenet/NntpClient.cs
@@ -75,7 +75,7 @@ public abstract class NntpClient : INntpClient
 
     public virtual async Task<UsenetYencHeader> GetYencHeadersAsync(string segmentId, CancellationToken ct)
     {
-        var decodedBodyResponse = await DecodedBodyAsync(segmentId, ct).ConfigureAwait(false);
+        var decodedBodyResponse = await this.DecodedBodyWithFallbackAsync(segmentId, ct).ConfigureAwait(false);
         await using var stream = decodedBodyResponse.Stream;
         var headers = await stream.GetYencHeadersAsync(ct).ConfigureAwait(false);
         return headers!;
@@ -83,8 +83,9 @@ public abstract class NntpClient : INntpClient
 
     public virtual async Task<long> GetFileSizeAsync(NzbFile file, CancellationToken ct)
     {
-        if (file.Segments.Count == 0) return 0;
-        var headers = await GetYencHeadersAsync(file.Segments[^1].MessageId, ct).ConfigureAwait(false);
+        var segmentIds = file.GetSegmentIds();
+        if (segmentIds.Length == 0) return 0;
+        var headers = await GetYencHeadersAsync(segmentIds[^1], ct).ConfigureAwait(false);
         return headers!.PartOffset + headers!.PartSize;
     }
 
@@ -119,7 +120,11 @@ public abstract class NntpClient : INntpClient
         var tasks = segmentIds
             .Select(async segmentId => (
                 SegmentId: segmentId,
-                Result: await StatAsync(segmentId, token).ConfigureAwait(false)
+                Result: await NntpClientSegmentFallbackExtensions.WithFallbackAsync(
+                    segmentId,
+                    (candidateSegmentId, ct) => StatAsync(candidateSegmentId, ct),
+                    token
+                ).ConfigureAwait(false)
             ))
             .WithConcurrencyAsync(concurrency);
 

--- a/backend/Clients/Usenet/NntpClientSegmentFallbackExtensions.cs
+++ b/backend/Clients/Usenet/NntpClientSegmentFallbackExtensions.cs
@@ -1,0 +1,97 @@
+using NzbWebDAV.Clients.Usenet.Models;
+using NzbWebDAV.Exceptions;
+using NzbWebDAV.Models.Nzb;
+using UsenetSharp.Models;
+
+namespace NzbWebDAV.Clients.Usenet;
+
+public static class NntpClientSegmentFallbackExtensions
+{
+    public static Task<UsenetHeadResponse> HeadWithFallbackAsync(
+        this INntpClient usenetClient,
+        string encodedSegmentId,
+        CancellationToken cancellationToken
+    )
+    {
+        return WithFallbackAsync(
+            encodedSegmentId,
+            (segmentId, ct) => usenetClient.HeadAsync(segmentId, ct),
+            cancellationToken
+        );
+    }
+
+    public static Task<UsenetDecodedArticleResponse> DecodedArticleWithFallbackAsync(
+        this INntpClient usenetClient,
+        string encodedSegmentId,
+        CancellationToken cancellationToken
+    )
+    {
+        return WithFallbackAsync(
+            encodedSegmentId,
+            (segmentId, ct) => usenetClient.DecodedArticleAsync(segmentId, ct),
+            cancellationToken
+        );
+    }
+
+    public static Task<UsenetDecodedBodyResponse> DecodedBodyWithFallbackAsync(
+        this INntpClient usenetClient,
+        string encodedSegmentId,
+        CancellationToken cancellationToken
+    )
+    {
+        return WithFallbackAsync(
+            encodedSegmentId,
+            (segmentId, ct) => usenetClient.DecodedBodyAsync(segmentId, ct),
+            cancellationToken
+        );
+    }
+
+    public static async Task<UsenetDecodedBodyResponse> DecodedBodyWithFallbackAsync(
+        this INntpClient usenetClient,
+        string encodedSegmentId,
+        CancellationToken cancellationToken,
+        Func<string, CancellationToken, Task<UsenetExclusiveConnection>> acquireExclusiveConnectionAsync
+    )
+    {
+        UsenetArticleNotFoundException? missingArticleException = null;
+        foreach (var segmentId in NzbSegmentIdSet.Decode(encodedSegmentId))
+        {
+            try
+            {
+                var exclusiveConnection = await acquireExclusiveConnectionAsync(segmentId, cancellationToken)
+                    .ConfigureAwait(false);
+                return await usenetClient
+                    .DecodedBodyAsync(segmentId, exclusiveConnection, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (UsenetArticleNotFoundException e)
+            {
+                missingArticleException = e;
+            }
+        }
+
+        throw missingArticleException ?? new UsenetArticleNotFoundException(encodedSegmentId);
+    }
+
+    public static async Task<T> WithFallbackAsync<T>(
+        string encodedSegmentId,
+        Func<string, CancellationToken, Task<T>> action,
+        CancellationToken cancellationToken
+    )
+    {
+        UsenetArticleNotFoundException? missingArticleException = null;
+        foreach (var segmentId in NzbSegmentIdSet.Decode(encodedSegmentId))
+        {
+            try
+            {
+                return await action(segmentId, cancellationToken).ConfigureAwait(false);
+            }
+            catch (UsenetArticleNotFoundException e)
+            {
+                missingArticleException = e;
+            }
+        }
+
+        throw missingArticleException ?? new UsenetArticleNotFoundException(encodedSegmentId);
+    }
+}

--- a/backend/Models/Nzb/NzbDocument.cs
+++ b/backend/Models/Nzb/NzbDocument.cs
@@ -100,8 +100,10 @@ public class NzbDocument
             if (reader is { NodeType: XmlNodeType.Element, Name: "segment" })
             {
                 var bytesAttr = reader.GetAttribute("bytes");
+                var numberAttr = reader.GetAttribute("number");
                 var segment = new NzbSegment
                 {
+                    Number = int.TryParse(numberAttr, out var number) ? number : 0,
                     Bytes = long.TryParse(bytesAttr, out var bytes) ? bytes : 0,
                     MessageId = await reader.ReadElementContentAsStringAsync().ConfigureAwait(false)
                 };

--- a/backend/Models/Nzb/NzbFile.cs
+++ b/backend/Models/Nzb/NzbFile.cs
@@ -9,16 +9,21 @@ public class NzbFile
 
     public string[] GetSegmentIds()
     {
-        return Segments
-            .Select(x => x.MessageId)
+        return GetLogicalSegments()
+            .Select(x => NzbSegmentIdSet.Encode(x.Select(segment => segment.MessageId).ToArray()))
             .ToArray();
     }
 
     public long GetTotalYencodedSize()
     {
-        return Segments
-            .Select(x => x.Bytes)
+        return GetLogicalSegments()
+            .Select(x => x[0].Bytes)
             .Sum();
+    }
+
+    public int GetLogicalSegmentCount()
+    {
+        return GetLogicalSegments().Count;
     }
 
     public string GetSubjectFileName()
@@ -51,5 +56,24 @@ public class NzbFile
             .Select(x => x.Invoke())
             .Where(x => x == Path.GetFileName(x))
             .FirstOrDefault(x => x != "") ?? "";
+    }
+
+    private List<List<NzbSegment>> GetLogicalSegments()
+    {
+        if (Segments.Count == 0)
+            return [];
+
+        if (Segments.All(segment => segment.Number > 0))
+        {
+            return Segments
+                .GroupBy(segment => segment.Number)
+                .OrderBy(group => group.Key)
+                .Select(group => group.ToList())
+                .ToList();
+        }
+
+        return Segments
+            .Select(segment => new List<NzbSegment> { segment })
+            .ToList();
     }
 }

--- a/backend/Models/Nzb/NzbSegment.cs
+++ b/backend/Models/Nzb/NzbSegment.cs
@@ -2,6 +2,7 @@ namespace NzbWebDAV.Models.Nzb;
 
 public class NzbSegment
 {
+    public required int Number { get; init; }
     public required long Bytes { get; init; }
     public required string MessageId { get; init; }
 }

--- a/backend/Models/Nzb/NzbSegmentIdSet.cs
+++ b/backend/Models/Nzb/NzbSegmentIdSet.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+
+namespace NzbWebDAV.Models.Nzb;
+
+public static class NzbSegmentIdSet
+{
+    public static string Encode(IReadOnlyList<string> segmentIds)
+    {
+        ArgumentNullException.ThrowIfNull(segmentIds);
+        if (segmentIds.Count == 0)
+            throw new ArgumentException("At least one segment id is required.", nameof(segmentIds));
+
+        return segmentIds.Count == 1
+            ? segmentIds[0]
+            : JsonSerializer.Serialize(segmentIds, (JsonSerializerOptions?)null);
+    }
+
+    public static string[] Decode(string encodedSegmentId)
+    {
+        if (string.IsNullOrWhiteSpace(encodedSegmentId))
+            return [];
+
+        if (encodedSegmentId[0] != '[')
+            return [encodedSegmentId];
+
+        try
+        {
+            var decoded = JsonSerializer.Deserialize<string[]>(encodedSegmentId, (JsonSerializerOptions?)null);
+            return decoded?
+                .Where(segmentId => !string.IsNullOrWhiteSpace(segmentId))
+                .ToArray()
+                   ?? [encodedSegmentId];
+        }
+        catch (JsonException)
+        {
+            return [encodedSegmentId];
+        }
+    }
+}

--- a/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
+++ b/backend/Queue/DeobfuscationSteps/1.FetchFirstSegment/FetchFirstSegmentsStep.cs
@@ -37,8 +37,10 @@ public static class FetchFirstSegmentsStep
         try
         {
             // get the first article stream
-            var firstSegment = nzbFile.Segments[0].MessageId;
-            var article = await usenetClient.DecodedArticleAsync(firstSegment, cancellationToken).ConfigureAwait(false);
+            var firstSegment = nzbFile.GetSegmentIds()[0];
+            var article = await usenetClient
+                .DecodedArticleWithFallbackAsync(firstSegment, cancellationToken)
+                .ConfigureAwait(false);
             await using var bodyStream = article.Stream!;
 
             // read up to the first 16KB from the stream

--- a/backend/Queue/DeobfuscationSteps/2.GetPar2FileDescriptors/GetPar2FileDescriptorsStep.cs
+++ b/backend/Queue/DeobfuscationSteps/2.GetPar2FileDescriptors/GetPar2FileDescriptorsStep.cs
@@ -19,13 +19,13 @@ public static class GetPar2FileDescriptorsStep
         var par2Index = files
             .Where(x => !x.MissingFirstSegment)
             .Where(x => Par2.HasPar2MagicBytes(x.First16KB!))
-            .MinBy(x => x.NzbFile.Segments.Count);
+            .MinBy(x => x.NzbFile.GetLogicalSegmentCount());
         if (par2Index is null) return [];
 
         // return all file descriptors
         var fileDescriptors = new List<FileDesc>();
         var segments = par2Index.NzbFile.GetSegmentIds();
-        var filesize = par2Index.NzbFile.Segments.Count == 1
+        var filesize = par2Index.NzbFile.GetLogicalSegmentCount() == 1
             ? par2Index.Header!.PartOffset + par2Index.Header!.PartSize
             : await usenetClient.GetFileSizeAsync(par2Index.NzbFile, cancellationToken).ConfigureAwait(false);
         await using var stream = usenetClient.GetFileStream(segments, filesize, articleBufferSize: 0);

--- a/backend/Queue/QueueItemProcessor.cs
+++ b/backend/Queue/QueueItemProcessor.cs
@@ -117,7 +117,7 @@ public class QueueItemProcessor(
 
         // step 0 -- perform article existence pre-check against cache
         // https://github.com/nzbdav-dev/nzbdav/issues/101
-        var articlesToPrecheck = nzbFiles.SelectMany(x => x.Segments).Select(x => x.MessageId);
+        var articlesToPrecheck = nzbFiles.SelectMany(x => x.GetSegmentIds());
         HealthCheckService.CheckCachedMissingSegmentIds(articlesToPrecheck);
 
         // step 1 -- get name and size of each nzb file

--- a/backend/Services/HealthCheckService.cs
+++ b/backend/Services/HealthCheckService.cs
@@ -6,6 +6,7 @@ using NzbWebDAV.Database;
 using NzbWebDAV.Database.Models;
 using NzbWebDAV.Exceptions;
 using NzbWebDAV.Extensions;
+using NzbWebDAV.Models.Nzb;
 using NzbWebDAV.Queue.PostProcessors;
 using NzbWebDAV.Utils;
 using NzbWebDAV.Websocket;
@@ -153,7 +154,8 @@ public class HealthCheckService : BackgroundService
             _ = _websocketManager.SendMessage(WebsocketTopic.HealthItemProgress, $"{davItem.Id}|done");
             if (FilenameUtil.IsImportantFileType(davItem.Name))
                 lock (_missingSegmentIds)
-                    _missingSegmentIds.Add(e.SegmentId);
+                    foreach (var segmentId in NzbSegmentIdSet.Decode(e.SegmentId))
+                        _missingSegmentIds.Add(segmentId);
 
             // when usenet article is missing, perform repairs
             await Repair(davItem, dbClient, ct).ConfigureAwait(false);
@@ -164,7 +166,7 @@ public class HealthCheckService : BackgroundService
     {
         var firstSegmentId = StringUtil.EmptyToNull(segments.FirstOrDefault());
         if (firstSegmentId == null) return;
-        var articleHeadersResponse = await _usenetClient.HeadAsync(firstSegmentId, ct).ConfigureAwait(false);
+        var articleHeadersResponse = await _usenetClient.HeadWithFallbackAsync(firstSegmentId, ct).ConfigureAwait(false);
         var articleHeaders = articleHeadersResponse.ArticleHeaders!;
         davItem.ReleaseDate = articleHeaders.Date;
     }
@@ -343,7 +345,7 @@ public class HealthCheckService : BackgroundService
         lock (_missingSegmentIds)
         {
             foreach (var segmentId in segmentIds)
-                if (_missingSegmentIds.Contains(segmentId))
+                if (NzbSegmentIdSet.Decode(segmentId).All(candidateSegmentId => _missingSegmentIds.Contains(candidateSegmentId)))
                     throw new UsenetArticleNotFoundException(segmentId);
         }
     }

--- a/backend/Streams/MultiSegmentStream.cs
+++ b/backend/Streams/MultiSegmentStream.cs
@@ -53,8 +53,7 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
                 var segmentId = _segmentIds.Span[i];
 
                 await _streamTasks.Writer.WaitToWriteAsync(cancellationToken);
-                var connection = await _usenetClient.AcquireExclusiveConnectionAsync(segmentId, cancellationToken);
-                var streamTask = DownloadSegment(segmentId, connection, cancellationToken);
+                var streamTask = DownloadSegment(segmentId, cancellationToken);
                 if (_streamTasks.Writer.TryWrite(streamTask)) continue;
 
                 // if we never get a chance to write the stream to the writer
@@ -74,12 +73,15 @@ public class MultiSegmentStream : FastReadOnlyNonSeekableStream
     private async Task<Stream> DownloadSegment
     (
         string segmentId,
-        UsenetExclusiveConnection exclusiveConnection,
         CancellationToken cancellationToken
     )
     {
         var bodyResponse = await _usenetClient
-            .DecodedBodyAsync(segmentId, exclusiveConnection, cancellationToken)
+            .DecodedBodyWithFallbackAsync(
+                segmentId,
+                cancellationToken,
+                (candidateSegmentId, ct) => _usenetClient.AcquireExclusiveConnectionAsync(candidateSegmentId, ct)
+            )
             .ConfigureAwait(false);
         return bodyResponse.Stream;
     }

--- a/backend/Streams/UnbufferedMultiSegmentStream.cs
+++ b/backend/Streams/UnbufferedMultiSegmentStream.cs
@@ -28,16 +28,18 @@ public class UnbufferedMultiSegmentStream : FastReadOnlyNonSeekableStream
             if (_stream == null)
             {
                 if (_currentIndex >= _segmentIds.Length) return 0;
-                var body = await _usenetClient.DecodedBodyAsync(_segmentIds.Span[_currentIndex++], cancellationToken);
+                var body = await _usenetClient
+                    .DecodedBodyWithFallbackAsync(_segmentIds.Span[_currentIndex++], cancellationToken)
+                    .ConfigureAwait(false);
                 _stream = body.Stream;
             }
 
             // read from the stream
-            var read = await _stream.ReadAsync(buffer, cancellationToken);
+            var read = await _stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
             if (read > 0) return read;
 
             // if the stream ended, continue to the next stream.
-            await _stream.DisposeAsync();
+            await _stream.DisposeAsync().ConfigureAwait(false);
             _stream = null;
         }
 


### PR DESCRIPTION
## Summary
- preserve NZB segment numbers and collapse duplicate numbers into a single logical segment with ordered fallback candidates
- retry duplicate segment candidates for STAT, HEAD, ARTICLE, BODY, streaming, queue prechecks, and health checks before treating a segment as missing
- add focused regression tests for duplicate-segment parsing and fallback streaming/check behavior

## Validation
- dotnet build backend/NzbWebDAV.csproj
- dotnet test backend.Tests/backend.Tests.csproj

Closes #252.