### PR TITLE
Recover missing /content items after restart

### DIFF
--- a/backend.Tests/GlobalUsings.cs
+++ b/backend.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/backend.Tests/Services/ContentIndexRecoveryServiceTests.cs
+++ b/backend.Tests/Services/ContentIndexRecoveryServiceTests.cs
@@ -1,0 +1,384 @@
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Services;
+using NzbWebDAV.Utils;
+
+namespace backend.Tests.Services;
+
+[Collection(nameof(ContentIndexDatabaseCollection))]
+public sealed class ContentIndexRecoveryServiceTests
+{
+    private readonly ContentIndexDatabaseFixture _fixture;
+
+    public ContentIndexRecoveryServiceTests(ContentIndexDatabaseFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task StartupRecovery_RestoresAllContent_WhenDatabaseComesUpEmpty()
+    {
+        var configManager = _fixture.CreateConfigManager();
+        var expectedItemId = Guid.NewGuid();
+
+        await using (var dbContext = await _fixture.ResetAndCreateMigratedContextAsync())
+        {
+            var movieDirectory = CreateDirectory("movies", DavItem.ContentFolder);
+            var movieFile = CreateNzbFile(expectedItemId, movieDirectory, "Example.mkv");
+
+            dbContext.Items.AddRange(movieDirectory, movieFile);
+            dbContext.NzbFiles.Add(new DavNzbFile
+            {
+                Id = movieFile.Id,
+                SegmentIds = ["segment-1", "segment-2"],
+            });
+
+            await dbContext.SaveChangesAsync();
+        }
+
+        await _fixture.RecreateDatabaseAsync();
+
+        var recoveryService = new ContentIndexRecoveryService(configManager);
+        await recoveryService.StartAsync(CancellationToken.None);
+
+        await using var restoredContext = await _fixture.CreateMigratedContextAsync();
+        Assert.Equal(
+            2,
+            await restoredContext.Items.CountAsync(x =>
+                x.Path.StartsWith(ContentPathUtil.ForwardSlashPrefix) || x.Path.StartsWith(ContentPathUtil.BackslashPrefix))
+        );
+        Assert.Equal(["segment-1", "segment-2"], (await restoredContext.NzbFiles.SingleAsync()).SegmentIds);
+    }
+
+    [Fact]
+    public async Task StartupRecovery_RestoresMissingMetadata_ForExistingContentItem()
+    {
+        var configManager = _fixture.CreateConfigManager();
+        var expectedItemId = Guid.NewGuid();
+
+        await using (var dbContext = await _fixture.ResetAndCreateMigratedContextAsync())
+        {
+            var movieDirectory = CreateDirectory("movies", DavItem.ContentFolder);
+            var movieFile = CreateNzbFile(expectedItemId, movieDirectory, "Example.mkv");
+
+            dbContext.Items.AddRange(movieDirectory, movieFile);
+            dbContext.NzbFiles.Add(new DavNzbFile
+            {
+                Id = movieFile.Id,
+                SegmentIds = ["segment-1", "segment-2"],
+            });
+
+            await dbContext.SaveChangesAsync();
+        }
+
+        await using (var dbContext = await _fixture.CreateMigratedContextAsync())
+        {
+            await dbContext.Database.ExecuteSqlRawAsync("DELETE FROM DavNzbFiles WHERE Id = {0}", expectedItemId);
+        }
+
+        var recoveryService = new ContentIndexRecoveryService(configManager);
+        await recoveryService.StartAsync(CancellationToken.None);
+
+        await using var restoredContext = await _fixture.CreateMigratedContextAsync();
+        Assert.Single(await restoredContext.NzbFiles.Where(x => x.Id == expectedItemId).ToListAsync());
+    }
+
+    [Fact]
+    public async Task StartupRecovery_RestoresLinkedMissingItems_WhenDatabaseIsPartiallyMissing()
+    {
+        var linkedItemId = Guid.NewGuid();
+        var missingDirectoryId = Guid.NewGuid();
+
+        await using (var dbContext = await _fixture.ResetAndCreateMigratedContextAsync())
+        {
+            var tvDirectory = CreateDirectory("tv", DavItem.ContentFolder);
+            var tvFile = CreateNzbFile(Guid.NewGuid(), tvDirectory, "Existing.mkv");
+            var movieDirectory = CreateDirectory(missingDirectoryId, "movies", DavItem.ContentFolder);
+            var movieFile = CreateNzbFile(linkedItemId, movieDirectory, "Missing.mkv");
+
+            dbContext.Items.AddRange(tvDirectory, tvFile, movieDirectory, movieFile);
+            dbContext.NzbFiles.AddRange(
+                new DavNzbFile { Id = tvFile.Id, SegmentIds = ["tv-segment"] },
+                new DavNzbFile { Id = movieFile.Id, SegmentIds = ["movie-segment"] }
+            );
+
+            await dbContext.SaveChangesAsync();
+        }
+
+        var libraryPath = _fixture.CreateLibraryDirectory();
+        var configManager = _fixture.CreateConfigManager(libraryPath);
+        await File.WriteAllTextAsync(
+            Path.Join(libraryPath, "Missing.strm"),
+            $"http://localhost:3000/view/.ids/{linkedItemId}.mkv?downloadKey=test&extension=mkv"
+        );
+
+        await using (var dbContext = await _fixture.CreateMigratedContextAsync())
+        {
+            await dbContext.Database.ExecuteSqlRawAsync("DELETE FROM DavItems WHERE Id = {0}", linkedItemId);
+            await dbContext.Database.ExecuteSqlRawAsync("DELETE FROM DavItems WHERE Id = {0}", missingDirectoryId);
+        }
+
+        var recoveryService = new ContentIndexRecoveryService(configManager);
+        await recoveryService.StartAsync(CancellationToken.None);
+
+        await using var restoredContext = await _fixture.CreateMigratedContextAsync();
+        var restoredPaths = await restoredContext.Items
+            .Where(x => x.Path.StartsWith(ContentPathUtil.ForwardSlashPrefix) || x.Path.StartsWith(ContentPathUtil.BackslashPrefix))
+            .Select(x => ContentPathUtil.NormalizeSeparators(x.Path))
+            .ToListAsync();
+
+        Assert.Contains("/content/movies", restoredPaths);
+        Assert.Contains("/content/movies/Missing.mkv", restoredPaths);
+        Assert.Single(await restoredContext.NzbFiles.Where(x => x.Id == linkedItemId).ToListAsync());
+    }
+
+    [Fact]
+    public async Task StartupRecovery_IgnoresUnsupportedSnapshotVersion()
+    {
+        var configManager = _fixture.CreateConfigManager();
+
+        await _fixture.ResetAsync();
+        Directory.CreateDirectory(Path.GetDirectoryName(ContentIndexSnapshotStore.SnapshotFilePath)!);
+        await File.WriteAllTextAsync(
+            ContentIndexSnapshotStore.SnapshotFilePath,
+            """{"Version":999,"GeneratedAtUtc":"2026-03-08T00:00:00+00:00","Items":[],"NzbFiles":[],"RarFiles":[],"MultipartFiles":[]}"""
+        );
+
+        await _fixture.RecreateDatabaseAsync();
+
+        var recoveryService = new ContentIndexRecoveryService(configManager);
+        await recoveryService.StartAsync(CancellationToken.None);
+
+        await using var restoredContext = await _fixture.CreateMigratedContextAsync();
+        Assert.Equal(
+            0,
+            await restoredContext.Items.CountAsync(x =>
+                x.Path.StartsWith(ContentPathUtil.ForwardSlashPrefix) || x.Path.StartsWith(ContentPathUtil.BackslashPrefix))
+        );
+    }
+
+    [Fact]
+    public async Task StartupRecovery_FallsBackToBackupSnapshot_WhenPrimarySnapshotIsCorrupt()
+    {
+        var configManager = _fixture.CreateConfigManager();
+        var expectedItemId = Guid.NewGuid();
+
+        await using (var dbContext = await _fixture.ResetAndCreateMigratedContextAsync())
+        {
+            var movieDirectory = CreateDirectory("movies", DavItem.ContentFolder);
+            var movieFile = CreateNzbFile(expectedItemId, movieDirectory, "Example.mkv");
+
+            dbContext.Items.AddRange(movieDirectory, movieFile);
+            dbContext.NzbFiles.Add(new DavNzbFile
+            {
+                Id = movieFile.Id,
+                SegmentIds = ["segment-1"],
+            });
+
+            await dbContext.SaveChangesAsync();
+        }
+
+        await File.WriteAllTextAsync(ContentIndexSnapshotStore.SnapshotFilePath, "not-json");
+        await _fixture.RecreateDatabaseAsync();
+
+        var recoveryService = new ContentIndexRecoveryService(configManager);
+        await recoveryService.StartAsync(CancellationToken.None);
+
+        await using var restoredContext = await _fixture.CreateMigratedContextAsync();
+        Assert.Single(await restoredContext.NzbFiles.Where(x => x.Id == expectedItemId).ToListAsync());
+    }
+
+    [Fact]
+    public async Task StartupRecovery_DoesNotBringBackDeletedItems_WhenSnapshotWasUpdatedAfterDeletion()
+    {
+        var configManager = _fixture.CreateConfigManager();
+        var deletedItemId = Guid.NewGuid();
+
+        await using (var dbContext = await _fixture.ResetAndCreateMigratedContextAsync())
+        {
+            var movieDirectory = CreateDirectory("movies", DavItem.ContentFolder);
+            var movieFile = CreateNzbFile(deletedItemId, movieDirectory, "Deleted.mkv");
+
+            dbContext.Items.AddRange(movieDirectory, movieFile);
+            dbContext.NzbFiles.Add(new DavNzbFile
+            {
+                Id = movieFile.Id,
+                SegmentIds = ["segment-1"],
+            });
+
+            await dbContext.SaveChangesAsync();
+            dbContext.Items.Remove(movieFile);
+            await dbContext.SaveChangesAsync();
+        }
+
+        await _fixture.RecreateDatabaseAsync();
+
+        var recoveryService = new ContentIndexRecoveryService(configManager);
+        await recoveryService.StartAsync(CancellationToken.None);
+
+        await using var restoredContext = await _fixture.CreateMigratedContextAsync();
+        Assert.DoesNotContain(await restoredContext.Items.Select(x => x.Id).ToListAsync(), x => x == deletedItemId);
+    }
+
+    [Fact]
+    public async Task SnapshotWriter_PreservesLastKnownGoodSnapshot_WhenMetadataRowsDisappear()
+    {
+        var expectedItemId = Guid.NewGuid();
+
+        await using (var dbContext = await _fixture.ResetAndCreateMigratedContextAsync())
+        {
+            var movieDirectory = CreateDirectory("movies", DavItem.ContentFolder);
+            var movieFile = CreateNzbFile(expectedItemId, movieDirectory, "Example.mkv");
+
+            dbContext.Items.AddRange(movieDirectory, movieFile);
+            dbContext.NzbFiles.Add(new DavNzbFile
+            {
+                Id = movieFile.Id,
+                SegmentIds = ["segment-1", "segment-2"],
+            });
+
+            await dbContext.SaveChangesAsync();
+        }
+
+        var originalSnapshot = await File.ReadAllTextAsync(ContentIndexSnapshotStore.SnapshotFilePath);
+
+        await using (var dbContext = await _fixture.CreateMigratedContextAsync())
+        {
+            dbContext.NzbFiles.Remove(await dbContext.NzbFiles.SingleAsync(x => x.Id == expectedItemId));
+            await dbContext.SaveChangesAsync();
+        }
+
+        var snapshotAfterCorruption = await File.ReadAllTextAsync(ContentIndexSnapshotStore.SnapshotFilePath);
+        Assert.Equal(originalSnapshot, snapshotAfterCorruption);
+    }
+
+    private static DavItem CreateDirectory(string name, DavItem parent)
+    {
+        return CreateDirectory(Guid.NewGuid(), name, parent);
+    }
+
+    private static DavItem CreateDirectory(Guid id, string name, DavItem parent)
+    {
+        return DavItem.New(id, parent, name, null, DavItem.ItemType.Directory, null, null);
+    }
+
+    private static DavItem CreateNzbFile(Guid id, DavItem parent, string name)
+    {
+        return DavItem.New(id, parent, name, 1024, DavItem.ItemType.NzbFile, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+    }
+}
+
+public sealed class ContentIndexDatabaseFixture : IAsyncLifetime
+{
+    private readonly string _configPath = Path.Join(Path.GetTempPath(), "nzbdav-tests", "content-index-recovery");
+
+    public ContentIndexDatabaseFixture()
+    {
+        Environment.SetEnvironmentVariable("CONFIG_PATH", _configPath);
+    }
+
+    public Task InitializeAsync()
+    {
+        Directory.CreateDirectory(_configPath);
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        return ResetAsync();
+    }
+
+    public async Task<DavDatabaseContext> ResetAndCreateMigratedContextAsync()
+    {
+        await ResetAsync();
+        return await CreateMigratedContextAsync();
+    }
+
+    public async Task<DavDatabaseContext> CreateMigratedContextAsync()
+    {
+        Directory.CreateDirectory(_configPath);
+        var dbContext = new DavDatabaseContext();
+        await dbContext.Database.MigrateAsync();
+        return dbContext;
+    }
+
+    public async Task RecreateDatabaseAsync()
+    {
+        await EnsureCleanDatabaseAsync(deleteSnapshots: false);
+    }
+
+    public async Task ResetAsync()
+    {
+        await EnsureCleanDatabaseAsync(deleteSnapshots: true);
+        DeleteDirectoryIfExists(Path.Join(_configPath, "library"));
+    }
+
+    public string CreateLibraryDirectory()
+    {
+        var libraryPath = Path.Join(_configPath, "library", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(libraryPath);
+        return libraryPath;
+    }
+
+    public ConfigManager CreateConfigManager(string? libraryPath = null)
+    {
+        var configManager = new ConfigManager();
+        var items = new List<ConfigItem>
+        {
+            new() { ConfigName = "rclone.mount-dir", ConfigValue = "/mnt/nzbdav" }
+        };
+
+        if (libraryPath != null)
+        {
+            items.Add(new ConfigItem
+            {
+                ConfigName = "media.library-dir",
+                ConfigValue = libraryPath
+            });
+        }
+
+        configManager.UpdateValues(items);
+        return configManager;
+    }
+
+    private static void DeleteIfExists(string path)
+    {
+        if (File.Exists(path))
+            File.Delete(path);
+    }
+
+    private static void DeleteDirectoryIfExists(string path)
+    {
+        if (Directory.Exists(path))
+            Directory.Delete(path, recursive: true);
+    }
+
+    private async Task EnsureCleanDatabaseAsync(bool deleteSnapshots)
+    {
+        Directory.CreateDirectory(_configPath);
+
+        await using var dbContext = new DavDatabaseContext();
+        await dbContext.Database.MigrateAsync();
+        await dbContext.HealthCheckResults.ExecuteDeleteAsync();
+        await dbContext.HealthCheckStats.ExecuteDeleteAsync();
+        await dbContext.QueueNzbContents.ExecuteDeleteAsync();
+        await dbContext.QueueItems.ExecuteDeleteAsync();
+        await dbContext.BlobCleanupItems.ExecuteDeleteAsync();
+        await dbContext.HistoryItems.ExecuteDeleteAsync();
+        await dbContext.Items
+            .Where(x => x.Path.StartsWith(ContentPathUtil.ForwardSlashPrefix) || x.Path.StartsWith(ContentPathUtil.BackslashPrefix))
+            .ExecuteDeleteAsync();
+
+        if (!deleteSnapshots) return;
+
+        DeleteIfExists(ContentIndexSnapshotStore.SnapshotFilePath);
+        DeleteIfExists(ContentIndexSnapshotStore.BackupSnapshotFilePath);
+    }
+}
+
+[CollectionDefinition(nameof(ContentIndexDatabaseCollection), DisableParallelization = true)]
+public sealed class ContentIndexDatabaseCollection : ICollectionFixture<ContentIndexDatabaseFixture>
+{
+}

--- a/backend.Tests/backend.Tests.csproj
+++ b/backend.Tests/backend.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\\backend\\NzbWebDAV.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/backend/Database/DavDatabaseContext.cs
+++ b/backend/Database/DavDatabaseContext.cs
@@ -15,7 +15,7 @@ public sealed class DavDatabaseContext() : DbContext(Options.Value)
     private static readonly Lazy<DbContextOptions<DavDatabaseContext>> Options = new(
         () => new DbContextOptionsBuilder<DavDatabaseContext>()
             .UseSqlite($"Data Source={DatabaseFilePath}")
-            .AddInterceptors(new SqliteForeignKeyEnabler())
+            .AddInterceptors(new SqliteForeignKeyEnabler(), new ContentIndexSnapshotInterceptor())
             .Options
     );
 

--- a/backend/Database/Interceptors/ContentIndexSnapshotInterceptor.cs
+++ b/backend/Database/Interceptors/ContentIndexSnapshotInterceptor.cs
@@ -1,0 +1,114 @@
+using System.Runtime.CompilerServices;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Services;
+using NzbWebDAV.Utils;
+using Serilog;
+
+namespace NzbWebDAV.Database.Interceptors;
+
+public sealed class ContentIndexSnapshotInterceptor : SaveChangesInterceptor
+{
+    private static readonly ConditionalWeakTable<DbContext, PendingSnapshotMarker> PendingSnapshots = new();
+
+    public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
+    {
+        MarkPendingSnapshot(eventData.Context);
+        return base.SavingChanges(eventData, result);
+    }
+
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync
+    (
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default
+    )
+    {
+        MarkPendingSnapshot(eventData.Context);
+        return base.SavingChangesAsync(eventData, result, cancellationToken);
+    }
+
+    public override int SavedChanges(SaveChangesCompletedEventData eventData, int result)
+    {
+        PersistSnapshotAsync(eventData.Context, CancellationToken.None).GetAwaiter().GetResult();
+        return base.SavedChanges(eventData, result);
+    }
+
+    public override async ValueTask<int> SavedChangesAsync
+    (
+        SaveChangesCompletedEventData eventData,
+        int result,
+        CancellationToken cancellationToken = default
+    )
+    {
+        await PersistSnapshotAsync(eventData.Context, cancellationToken).ConfigureAwait(false);
+        return await base.SavedChangesAsync(eventData, result, cancellationToken).ConfigureAwait(false);
+    }
+
+    public override void SaveChangesFailed(DbContextErrorEventData eventData)
+    {
+        ClearPendingSnapshot(eventData.Context);
+        base.SaveChangesFailed(eventData);
+    }
+
+    public override Task SaveChangesFailedAsync
+    (
+        DbContextErrorEventData eventData,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ClearPendingSnapshot(eventData.Context);
+        return base.SaveChangesFailedAsync(eventData, cancellationToken);
+    }
+
+    private static async Task PersistSnapshotAsync(DbContext? context, CancellationToken cancellationToken)
+    {
+        if (context is not DavDatabaseContext dbContext) return;
+        if (!PendingSnapshots.TryGetValue(dbContext, out _)) return;
+        PendingSnapshots.Remove(dbContext);
+
+        try
+        {
+            await ContentIndexSnapshotStore.WriteAsync(dbContext, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to persist /content recovery snapshot.");
+        }
+    }
+
+    private static void MarkPendingSnapshot(DbContext? dbContext)
+    {
+        if (dbContext == null || !HasContentIndexChanges(dbContext)) return;
+        PendingSnapshots.GetValue(dbContext, _ => new PendingSnapshotMarker());
+    }
+
+    private static void ClearPendingSnapshot(DbContext? dbContext)
+    {
+        if (dbContext == null) return;
+        PendingSnapshots.Remove(dbContext);
+    }
+
+    private static bool HasContentIndexChanges(DbContext dbContext)
+    {
+        return dbContext.ChangeTracker.Entries().Any(entry =>
+        {
+            if (entry.State is not (EntityState.Added or EntityState.Modified or EntityState.Deleted))
+                return false;
+
+            return entry.Entity switch
+            {
+                DavItem item => ContentPathUtil.IsContentChildPath(item.Path),
+                DavNzbFile => true,
+                DavRarFile => true,
+                DavMultipartFile => true,
+                _ => false
+            };
+        });
+    }
+
+    private sealed class PendingSnapshotMarker
+    {
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -83,6 +83,7 @@ class Program
             .AddSingleton(websocketManager)
             .AddSingleton<UsenetStreamingClient>()
             .AddSingleton<QueueManager>()
+            .AddHostedService<ContentIndexRecoveryService>()
             .AddHostedService<HealthCheckService>()
             .AddHostedService<ArrMonitoringService>()
             .AddHostedService<BlobCleanupService>()

--- a/backend/Services/ContentIndexRecoveryService.cs
+++ b/backend/Services/ContentIndexRecoveryService.cs
@@ -1,0 +1,297 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using NzbWebDAV.Config;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Utils;
+using Serilog;
+
+namespace NzbWebDAV.Services;
+
+public sealed class ContentIndexRecoveryService(ConfigManager configManager) : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var snapshotReadResult = await ContentIndexSnapshotStore.ReadAsync(cancellationToken).ConfigureAwait(false);
+            foreach (var warning in snapshotReadResult.Warnings)
+                Log.Warning(warning);
+
+            var snapshot = snapshotReadResult.Snapshot;
+            if (snapshot == null || snapshot.Items.Count == 0) return;
+
+            await using var dbContext = new DavDatabaseContext();
+            var plan = await BuildRecoveryPlanAsync(dbContext, snapshot, configManager, cancellationToken).ConfigureAwait(false);
+            if (!plan.NeedsRecovery) return;
+
+            Log.Warning(
+                "Recovering /content from snapshot '{SourcePath}'. Full restore: {RestoreAll}. Missing items: {MissingItems}. Missing metadata rows: {MissingMetadata}.",
+                snapshotReadResult.SourcePath,
+                plan.RestoreAllContentItems,
+                plan.MissingItemIds.Count,
+                plan.MissingNzbFileIds.Count + plan.MissingRarFileIds.Count + plan.MissingMultipartFileIds.Count
+            );
+
+            await RestoreAsync(dbContext, snapshot, plan, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to restore /content items from persisted snapshot.");
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    internal static async Task<RecoveryPlan> BuildRecoveryPlanAsync
+    (
+        DavDatabaseContext dbContext,
+        ContentIndexSnapshotStore.ContentIndexSnapshot snapshot,
+        ConfigManager configManager,
+        CancellationToken cancellationToken
+    )
+    {
+        var currentItems = await dbContext.Items
+            .AsNoTracking()
+            .Where(x => x.Path.StartsWith(ContentPathUtil.ForwardSlashPrefix) || x.Path.StartsWith(ContentPathUtil.BackslashPrefix))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (currentItems.Count == 0)
+        {
+            return new RecoveryPlan
+            {
+                RestoreAllContentItems = true,
+            };
+        }
+
+        var snapshotItemsById = snapshot.Items.ToDictionary(x => x.Id);
+        var currentItemsById = currentItems.ToDictionary(x => x.Id);
+        var missingItemIds = new HashSet<Guid>();
+
+        foreach (var item in currentItems)
+        {
+            if (item.ParentId == null || item.ParentId == DavItem.ContentFolder.Id) continue;
+            if (currentItemsById.ContainsKey(item.ParentId.Value)) continue;
+            AddItemAndAncestors(item.ParentId.Value, snapshotItemsById, missingItemIds);
+        }
+
+        foreach (var linkedItemId in GetLinkedItemIds(configManager))
+        {
+            if (currentItemsById.ContainsKey(linkedItemId)) continue;
+            AddItemAndAncestors(linkedItemId, snapshotItemsById, missingItemIds);
+        }
+
+        var effectiveItemsById = snapshot.Items
+            .Where(x => currentItemsById.ContainsKey(x.Id) || missingItemIds.Contains(x.Id))
+            .ToDictionary(x => x.Id);
+        var effectiveFileItems = effectiveItemsById.Values
+            .Where(x => x.Type is DavItem.ItemType.NzbFile or DavItem.ItemType.RarFile or DavItem.ItemType.MultipartFile)
+            .ToArray();
+        var effectiveIds = effectiveFileItems.Select(x => x.Id).ToHashSet();
+
+        var currentNzbIds = await dbContext.NzbFiles
+            .AsNoTracking()
+            .Where(x => effectiveIds.Contains(x.Id))
+            .Select(x => x.Id)
+            .ToHashSetAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var currentRarIds = await dbContext.RarFiles
+            .AsNoTracking()
+            .Where(x => effectiveIds.Contains(x.Id))
+            .Select(x => x.Id)
+            .ToHashSetAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var currentMultipartIds = await dbContext.MultipartFiles
+            .AsNoTracking()
+            .Where(x => effectiveIds.Contains(x.Id))
+            .Select(x => x.Id)
+            .ToHashSetAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return new RecoveryPlan
+        {
+            MissingItemIds = missingItemIds,
+            MissingNzbFileIds = effectiveFileItems
+                .Where(x => x.Type == DavItem.ItemType.NzbFile && !currentNzbIds.Contains(x.Id))
+                .Select(x => x.Id)
+                .ToHashSet(),
+            MissingRarFileIds = effectiveFileItems
+                .Where(x => x.Type == DavItem.ItemType.RarFile && !currentRarIds.Contains(x.Id))
+                .Select(x => x.Id)
+                .ToHashSet(),
+            MissingMultipartFileIds = effectiveFileItems
+                .Where(x => x.Type == DavItem.ItemType.MultipartFile && !currentMultipartIds.Contains(x.Id))
+                .Select(x => x.Id)
+                .ToHashSet(),
+        };
+    }
+
+    internal static async Task RestoreAsync
+    (
+        DavDatabaseContext dbContext,
+        ContentIndexSnapshotStore.ContentIndexSnapshot snapshot,
+        RecoveryPlan plan,
+        CancellationToken cancellationToken
+    )
+    {
+        if (!plan.NeedsRecovery) return;
+
+        var existingItemIds = await dbContext.Items
+            .Where(x => x.Path.StartsWith(ContentPathUtil.ForwardSlashPrefix) || x.Path.StartsWith(ContentPathUtil.BackslashPrefix))
+            .Select(x => x.Id)
+            .ToHashSetAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var itemIdsToRestore = plan.RestoreAllContentItems
+            ? snapshot.Items.Select(x => x.Id).ToHashSet()
+            : new HashSet<Guid>(plan.MissingItemIds);
+
+        foreach (var item in snapshot.Items
+                     .Where(x => itemIdsToRestore.Contains(x.Id))
+                     .OrderBy(x => ContentPathUtil.NormalizeSeparators(x.Path).Count(c => c == '/'))
+                     .ThenBy(x => ContentPathUtil.NormalizeSeparators(x.Path), StringComparer.Ordinal))
+        {
+            if (existingItemIds.Contains(item.Id)) continue;
+
+            dbContext.Items.Add(Clone(item));
+            existingItemIds.Add(item.Id);
+        }
+
+        var existingNzbIds = await dbContext.NzbFiles
+            .Where(x => existingItemIds.Contains(x.Id))
+            .Select(x => x.Id)
+            .ToHashSetAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var existingRarIds = await dbContext.RarFiles
+            .Where(x => existingItemIds.Contains(x.Id))
+            .Select(x => x.Id)
+            .ToHashSetAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var existingMultipartIds = await dbContext.MultipartFiles
+            .Where(x => existingItemIds.Contains(x.Id))
+            .Select(x => x.Id)
+            .ToHashSetAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var nzbIdsToRestore = plan.RestoreAllContentItems
+            ? snapshot.NzbFiles.Select(x => x.Id).ToHashSet()
+            : plan.MissingNzbFileIds;
+        foreach (var nzbFile in snapshot.NzbFiles.Where(x => nzbIdsToRestore.Contains(x.Id)))
+        {
+            if (!existingItemIds.Contains(nzbFile.Id) || existingNzbIds.Contains(nzbFile.Id)) continue;
+
+            dbContext.NzbFiles.Add(new DavNzbFile
+            {
+                Id = nzbFile.Id,
+                SegmentIds = nzbFile.SegmentIds,
+            });
+            existingNzbIds.Add(nzbFile.Id);
+        }
+
+        var rarIdsToRestore = plan.RestoreAllContentItems
+            ? snapshot.RarFiles.Select(x => x.Id).ToHashSet()
+            : plan.MissingRarFileIds;
+        foreach (var rarFile in snapshot.RarFiles.Where(x => rarIdsToRestore.Contains(x.Id)))
+        {
+            if (!existingItemIds.Contains(rarFile.Id) || existingRarIds.Contains(rarFile.Id)) continue;
+
+            dbContext.RarFiles.Add(new DavRarFile
+            {
+                Id = rarFile.Id,
+                RarParts = rarFile.RarParts,
+            });
+            existingRarIds.Add(rarFile.Id);
+        }
+
+        var multipartIdsToRestore = plan.RestoreAllContentItems
+            ? snapshot.MultipartFiles.Select(x => x.Id).ToHashSet()
+            : plan.MissingMultipartFileIds;
+        foreach (var multipartFile in snapshot.MultipartFiles.Where(x => multipartIdsToRestore.Contains(x.Id)))
+        {
+            if (!existingItemIds.Contains(multipartFile.Id) || existingMultipartIds.Contains(multipartFile.Id)) continue;
+
+            dbContext.MultipartFiles.Add(new DavMultipartFile
+            {
+                Id = multipartFile.Id,
+                Metadata = multipartFile.Metadata,
+            });
+            existingMultipartIds.Add(multipartFile.Id);
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static void AddItemAndAncestors
+    (
+        Guid itemId,
+        IReadOnlyDictionary<Guid, DavItem> snapshotItemsById,
+        ISet<Guid> missingItemIds
+    )
+    {
+        var currentId = itemId;
+        while (snapshotItemsById.TryGetValue(currentId, out var item))
+        {
+            if (!missingItemIds.Add(currentId)) break;
+            if (item.ParentId == null || item.ParentId == DavItem.ContentFolder.Id) break;
+            currentId = item.ParentId.Value;
+        }
+    }
+
+    private static IEnumerable<Guid> GetLinkedItemIds(ConfigManager configManager)
+    {
+        var libraryDir = configManager.GetLibraryDir();
+        if (string.IsNullOrWhiteSpace(libraryDir) || !Directory.Exists(libraryDir))
+            return [];
+
+        try
+        {
+            return OrganizedLinksUtil.GetLibraryDavItemLinks(configManager)
+                .Select(x => x.DavItemId)
+                .Distinct()
+                .ToArray();
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to inspect library links while evaluating /content recovery.");
+            return [];
+        }
+    }
+
+    private static DavItem Clone(DavItem item)
+    {
+        return new DavItem
+        {
+            Id = item.Id,
+            IdPrefix = item.IdPrefix,
+            CreatedAt = item.CreatedAt,
+            ParentId = item.ParentId,
+            Name = item.Name,
+            FileSize = item.FileSize,
+            Type = item.Type,
+            Path = item.Path,
+            ReleaseDate = item.ReleaseDate,
+            LastHealthCheck = item.LastHealthCheck,
+            NextHealthCheck = item.NextHealthCheck,
+        };
+    }
+
+    internal sealed class RecoveryPlan
+    {
+        public bool RestoreAllContentItems { get; init; }
+        public HashSet<Guid> MissingItemIds { get; init; } = [];
+        public HashSet<Guid> MissingNzbFileIds { get; init; } = [];
+        public HashSet<Guid> MissingRarFileIds { get; init; } = [];
+        public HashSet<Guid> MissingMultipartFileIds { get; init; } = [];
+
+        public bool NeedsRecovery =>
+            RestoreAllContentItems
+            || MissingItemIds.Count > 0
+            || MissingNzbFileIds.Count > 0
+            || MissingRarFileIds.Count > 0
+            || MissingMultipartFileIds.Count > 0;
+    }
+}

--- a/backend/Services/ContentIndexSnapshotStore.cs
+++ b/backend/Services/ContentIndexSnapshotStore.cs
@@ -1,0 +1,310 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using NzbWebDAV.Database;
+using NzbWebDAV.Database.Models;
+using NzbWebDAV.Utils;
+
+namespace NzbWebDAV.Services;
+
+public static class ContentIndexSnapshotStore
+{
+    public const int CurrentVersion = 1;
+
+    private const string SnapshotFileName = "content-index.snapshot.json";
+    private const string BackupSnapshotFileName = "content-index.snapshot.backup.json";
+    private static readonly SemaphoreSlim Mutex = new(1, 1);
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = false
+    };
+
+    public static string SnapshotFilePath => Path.Join(DavDatabaseContext.ConfigPath, SnapshotFileName);
+    public static string BackupSnapshotFilePath => Path.Join(DavDatabaseContext.ConfigPath, BackupSnapshotFileName);
+
+    public static async Task WriteAsync(DavDatabaseContext dbContext, CancellationToken cancellationToken)
+    {
+        var snapshot = await CreateSnapshotAsync(dbContext, cancellationToken).ConfigureAwait(false);
+        if (!TryValidate(snapshot, out var validationError))
+        {
+            throw new InvalidOperationException(
+                $"Refused to overwrite /content recovery snapshot with inconsistent state: {validationError}"
+            );
+        }
+
+        await Mutex.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            Directory.CreateDirectory(DavDatabaseContext.ConfigPath);
+            var tempFilePath = SnapshotFilePath + ".tmp";
+
+            try
+            {
+                await using (var stream = File.Create(tempFilePath))
+                {
+                    await JsonSerializer.SerializeAsync(stream, snapshot, JsonOptions, cancellationToken).ConfigureAwait(false);
+                }
+
+                File.Move(tempFilePath, SnapshotFilePath, overwrite: true);
+                File.Copy(SnapshotFilePath, BackupSnapshotFilePath, overwrite: true);
+            }
+            finally
+            {
+                if (File.Exists(tempFilePath))
+                    File.Delete(tempFilePath);
+            }
+        }
+        finally
+        {
+            Mutex.Release();
+        }
+    }
+
+    public static async Task<SnapshotReadResult> ReadAsync(CancellationToken cancellationToken)
+    {
+        await Mutex.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var warnings = new List<string>();
+            var primaryResult = await TryReadPathAsync(SnapshotFilePath, cancellationToken).ConfigureAwait(false);
+            if (primaryResult.Snapshot != null)
+                return primaryResult;
+            if (primaryResult.Warning != null)
+                warnings.Add(primaryResult.Warning);
+
+            var backupResult = await TryReadPathAsync(BackupSnapshotFilePath, cancellationToken).ConfigureAwait(false);
+            if (backupResult.Snapshot != null)
+            {
+                warnings.AddRange(backupResult.Warnings);
+                return new SnapshotReadResult
+                {
+                    Snapshot = backupResult.Snapshot,
+                    SourcePath = backupResult.SourcePath,
+                    Warnings = warnings,
+                };
+            }
+
+            if (backupResult.Warning != null)
+                warnings.Add(backupResult.Warning);
+
+            return new SnapshotReadResult { Warnings = warnings };
+        }
+        finally
+        {
+            Mutex.Release();
+        }
+    }
+
+    private static async Task<SnapshotReadResult> TryReadPathAsync(string path, CancellationToken cancellationToken)
+    {
+        if (!File.Exists(path)) return new SnapshotReadResult();
+
+        try
+        {
+            await using var stream = File.OpenRead(path);
+            var snapshot = await JsonSerializer
+                .DeserializeAsync<ContentIndexSnapshot>(stream, JsonOptions, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (snapshot == null)
+            {
+                return new SnapshotReadResult
+                {
+                    Warning = $"Ignored /content recovery snapshot at '{path}' because it deserialized to null."
+                };
+            }
+
+            if (!TryValidate(snapshot, out var validationError))
+            {
+                return new SnapshotReadResult
+                {
+                    Warning = $"Ignored /content recovery snapshot at '{path}': {validationError}"
+                };
+            }
+
+            return new SnapshotReadResult
+            {
+                Snapshot = snapshot,
+                SourcePath = path,
+            };
+        }
+        catch (Exception ex)
+        {
+            return new SnapshotReadResult
+            {
+                Warning = $"Ignored /content recovery snapshot at '{path}': {ex.Message}"
+            };
+        }
+    }
+
+    private static bool TryValidate(ContentIndexSnapshot snapshot, out string error)
+    {
+        if (snapshot.Version != CurrentVersion)
+        {
+            error = $"unsupported version {snapshot.Version}";
+            return false;
+        }
+
+        if (!TryBuildUniqueDictionary(snapshot.Items, x => x.Id, out var itemsById, out var duplicateItemId))
+        {
+            error = $"duplicate DavItem id {duplicateItemId}";
+            return false;
+        }
+
+        foreach (var item in snapshot.Items)
+        {
+            if (!ContentPathUtil.IsContentChildPath(item.Path))
+            {
+                error = $"item '{item.Id}' has non-content path '{item.Path}'";
+                return false;
+            }
+
+            if (item.ParentId != DavItem.ContentFolder.Id && !itemsById.ContainsKey(item.ParentId!.Value))
+            {
+                error = $"item '{item.Id}' references missing parent '{item.ParentId}'";
+                return false;
+            }
+        }
+
+        if (!TryBuildUniqueDictionary(snapshot.NzbFiles, x => x.Id, out var nzbFilesById, out _))
+        {
+            error = "duplicate DavNzbFile ids";
+            return false;
+        }
+
+        if (!TryBuildUniqueDictionary(snapshot.RarFiles, x => x.Id, out var rarFilesById, out _))
+        {
+            error = "duplicate DavRarFile ids";
+            return false;
+        }
+
+        if (!TryBuildUniqueDictionary(snapshot.MultipartFiles, x => x.Id, out var multipartFilesById, out _))
+        {
+            error = "duplicate DavMultipartFile ids";
+            return false;
+        }
+
+        foreach (var item in snapshot.Items)
+        {
+            var hasRequiredMetadata = item.Type switch
+            {
+                DavItem.ItemType.Directory => true,
+                DavItem.ItemType.NzbFile => nzbFilesById.ContainsKey(item.Id),
+                DavItem.ItemType.RarFile => rarFilesById.ContainsKey(item.Id),
+                DavItem.ItemType.MultipartFile => multipartFilesById.ContainsKey(item.Id),
+                _ => false
+            };
+
+            if (!hasRequiredMetadata)
+            {
+                error = $"item '{item.Id}' is missing required metadata";
+                return false;
+            }
+        }
+
+        if (snapshot.NzbFiles.Any(x => !itemsById.TryGetValue(x.Id, out var item) || item.Type != DavItem.ItemType.NzbFile))
+        {
+            error = "snapshot contains DavNzbFile rows without matching NzbFile items";
+            return false;
+        }
+
+        if (snapshot.RarFiles.Any(x => !itemsById.TryGetValue(x.Id, out var item) || item.Type != DavItem.ItemType.RarFile))
+        {
+            error = "snapshot contains DavRarFile rows without matching RarFile items";
+            return false;
+        }
+
+        if (snapshot.MultipartFiles.Any(x => !itemsById.TryGetValue(x.Id, out var item) || item.Type != DavItem.ItemType.MultipartFile))
+        {
+            error = "snapshot contains DavMultipartFile rows without matching MultipartFile items";
+            return false;
+        }
+
+        error = string.Empty;
+        return true;
+    }
+
+    private static async Task<ContentIndexSnapshot> CreateSnapshotAsync
+    (
+        DavDatabaseContext dbContext,
+        CancellationToken cancellationToken
+    )
+    {
+        var items = await dbContext.Items
+            .AsNoTracking()
+            .Where(x => x.Path.StartsWith(ContentPathUtil.ForwardSlashPrefix) || x.Path.StartsWith(ContentPathUtil.BackslashPrefix))
+            .OrderBy(x => x.Path)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var itemIds = items.Select(x => x.Id).ToHashSet();
+
+        var nzbFiles = await dbContext.NzbFiles
+            .AsNoTracking()
+            .Where(x => itemIds.Contains(x.Id))
+            .OrderBy(x => x.Id)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var rarFiles = await dbContext.RarFiles
+            .AsNoTracking()
+            .Where(x => itemIds.Contains(x.Id))
+            .OrderBy(x => x.Id)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var multipartFiles = await dbContext.MultipartFiles
+            .AsNoTracking()
+            .Where(x => itemIds.Contains(x.Id))
+            .OrderBy(x => x.Id)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return new ContentIndexSnapshot
+        {
+            Version = CurrentVersion,
+            GeneratedAtUtc = DateTimeOffset.UtcNow,
+            Items = items,
+            NzbFiles = nzbFiles,
+            RarFiles = rarFiles,
+            MultipartFiles = multipartFiles,
+        };
+    }
+
+    private static bool TryBuildUniqueDictionary<TValue>
+    (
+        IEnumerable<TValue> values,
+        Func<TValue, Guid> keySelector,
+        out Dictionary<Guid, TValue> result,
+        out Guid duplicateKey
+    )
+    {
+        result = new Dictionary<Guid, TValue>();
+        foreach (var value in values)
+        {
+            var key = keySelector(value);
+            if (!result.TryAdd(key, value))
+            {
+                duplicateKey = key;
+                return false;
+            }
+        }
+
+        duplicateKey = Guid.Empty;
+        return true;
+    }
+
+    public sealed class SnapshotReadResult
+    {
+        public ContentIndexSnapshot? Snapshot { get; init; }
+        public string? SourcePath { get; init; }
+        public string? Warning { get; init; }
+        public List<string> Warnings { get; init; } = [];
+    }
+
+    public sealed class ContentIndexSnapshot
+    {
+        public int Version { get; init; }
+        public DateTimeOffset GeneratedAtUtc { get; init; }
+        public List<DavItem> Items { get; init; } = [];
+        public List<DavNzbFile> NzbFiles { get; init; } = [];
+        public List<DavRarFile> RarFiles { get; init; } = [];
+        public List<DavMultipartFile> MultipartFiles { get; init; } = [];
+    }
+}

--- a/backend/Utils/ContentPathUtil.cs
+++ b/backend/Utils/ContentPathUtil.cs
@@ -1,0 +1,18 @@
+namespace NzbWebDAV.Utils;
+
+public static class ContentPathUtil
+{
+    public const string ForwardSlashPrefix = "/content/";
+    public const string BackslashPrefix = "/content\\";
+
+    public static bool IsContentChildPath(string path)
+    {
+        return path.StartsWith(ForwardSlashPrefix, StringComparison.Ordinal)
+               || path.StartsWith(BackslashPrefix, StringComparison.Ordinal);
+    }
+
+    public static string NormalizeSeparators(string path)
+    {
+        return path.Replace('\\', '/');
+    }
+}


### PR DESCRIPTION
Fixes #304.

`/content` is a database-backed WebDAV view, not a real media folder on disk. If nzbdav starts after a reboot with `/content` rows missing from `db.sqlite`, the files appear to disappear even though the app did not intentionally delete them.

This change adds a guarded recovery path:
- persist a snapshot of the `/content` subtree and its file metadata under `/config`
- restore missing `/content` rows and matching file metadata at startup when the DB is empty or partially missing
- restore linked missing items and required parent directories when the snapshot still has them
- validate snapshots before using them, fall back to a backup copy if the primary snapshot is corrupt, and refuse to overwrite the last known-good snapshot with inconsistent state

Healthy startup behavior is unchanged, and intentional deletes stay deleted because valid post-delete snapshots replace the prior state.

Tests cover:
- full restore when `/content` starts empty
- metadata-only recovery for existing items
- partial recovery for linked missing items
- unsupported snapshot versions
- corrupt primary snapshot with backup fallback
- preserving the last known-good snapshot when metadata rows disappear
- not restoring intentionally deleted items

Validation:
- `dotnet build backend/NzbWebDAV.csproj`
- `dotnet test backend.Tests/backend.Tests.csproj`

This does not recover anything if `/config` itself is not persistent, because both the DB and the recovery snapshot are gone in that case.