### PR TITLE
fix(#309): preserve extensions for .ids paths

### DIFF
--- a/backend/Queue/PostProcessors/CreateStrmFilesPostProcessor.cs
+++ b/backend/Queue/PostProcessors/CreateStrmFilesPostProcessor.cs
@@ -46,7 +46,7 @@ public class CreateStrmFilesPostProcessor(ConfigManager configManager, DavDataba
     {
         var baseUrl = configManager.GetBaseUrl();
         if (baseUrl.EndsWith('/')) baseUrl = baseUrl.TrimEnd('/');
-        var pathUrl = DatabaseStoreSymlinkFile.GetTargetPath(davItem.Id, "", '/');
+        var pathUrl = DatabaseStoreSymlinkFile.GetTargetPath(davItem.Id, "", '/', davItem.Name);
         if (pathUrl.StartsWith('/')) pathUrl = pathUrl.TrimStart('/');
         var strmKey = configManager.GetStrmKey();
         var downloadKey = GetWebdavItemRequest.GenerateDownloadKey(strmKey, pathUrl);

--- a/backend/Tasks/StrmToSymlinksTask.cs
+++ b/backend/Tasks/StrmToSymlinksTask.cs
@@ -80,7 +80,12 @@ public class StrmToSymlinksTask(
         foreach (var item in itemsWithExtension)
         {
             var symlinkPath = PathUtil.ReplaceExtension(item.Link.LinkPath, item.Extension);
-            var symlinkTarget = DatabaseStoreSymlinkFile.GetTargetPath(item.Link.DavItemId, mountDir);
+            var originalFileName = string.IsNullOrWhiteSpace(item.Extension) ? null : $"file.{item.Extension}";
+            var symlinkTarget = DatabaseStoreSymlinkFile.GetTargetPath(
+                item.Link.DavItemId,
+                mountDir,
+                originalFileName: originalFileName
+            );
             await Task.Run(() =>
             {
                 File.CreateSymbolicLink(symlinkPath, symlinkTarget);

--- a/backend/WebDav/DatabaseStoreIdFile.cs
+++ b/backend/WebDav/DatabaseStoreIdFile.cs
@@ -16,7 +16,7 @@ public class DatabaseStoreIdFile(
     ConfigManager configManager
 ) : BaseStoreReadonlyItem
 {
-    public override string Name => davItem.Id.ToString();
+    public override string Name => GetPathName(davItem);
     public override string UniqueKey => davItem.Id.ToString();
     public override long FileSize => davItem.FileSize!.Value;
     public override DateTime CreatedAt => davItem.CreatedAt;
@@ -24,6 +24,14 @@ public class DatabaseStoreIdFile(
     public override Task<Stream> GetReadableStreamAsync(CancellationToken cancellationToken)
     {
         return GetItem(davItem).GetReadableStreamAsync(cancellationToken);
+    }
+
+    public static string GetPathName(DavItem davItem)
+    {
+        var extension = Path.GetExtension(davItem.Name);
+        return string.IsNullOrEmpty(extension)
+            ? davItem.Id.ToString()
+            : $"{davItem.Id}{extension}";
     }
 
     private IStoreItem GetItem(DavItem davItem)

--- a/backend/WebDav/DatabaseStoreIdsCollection.cs
+++ b/backend/WebDav/DatabaseStoreIdsCollection.cs
@@ -40,7 +40,8 @@ public class DatabaseStoreIdsCollection(
             return new DatabaseStoreIdsCollection(dir, Path.Join(currentPath, dir), ctx, db, usenet, config);
         }
 
-        var item = await dbClient.GetFileById(request.Name).ConfigureAwait(false);
+        var itemId = GetItemIdFromPathName(request.Name);
+        var item = await dbClient.GetFileById(itemId).ConfigureAwait(false);
         return item == null ? null : new DatabaseStoreIdFile(item, ctx, dbClient, usenet, config);
     }
 
@@ -64,5 +65,10 @@ public class DatabaseStoreIdsCollection(
     protected override bool SupportsFastMove(SupportsFastMoveRequest request)
     {
         return false;
+    }
+
+    public static string GetItemIdFromPathName(string pathName)
+    {
+        return Path.GetFileNameWithoutExtension(pathName);
     }
 }

--- a/backend/WebDav/DatabaseStoreSymlinkFile.cs
+++ b/backend/WebDav/DatabaseStoreSymlinkFile.cs
@@ -22,16 +22,22 @@ public class DatabaseStoreSymlinkFile(DavItem davFile, ConfigManager configManag
 
     private string GetTargetPath()
     {
-        return GetTargetPath(davFile.Id, configManager.GetRcloneMountDir());
+        return GetTargetPath(davFile.Id, configManager.GetRcloneMountDir(), originalFileName: davFile.Name);
     }
 
-    public static string GetTargetPath(Guid davItemId, string mountDir, char? pathSeparator = null)
+    public static string GetTargetPath(
+        Guid davItemId,
+        string mountDir,
+        char? pathSeparator = null,
+        string? originalFileName = null
+    )
     {
+        var extension = Path.GetExtension(originalFileName ?? string.Empty);
         var pathParts = davItemId.GetFiveLengthPrefix()
             .Select(x => x.ToString())
             .Prepend(DavItem.IdsFolder.Name)
             .Prepend(mountDir)
-            .Append(davItemId.ToString())
+            .Append($"{davItemId}{extension}")
             .ToArray();
         return string.Join(pathSeparator ?? Path.DirectorySeparatorChar, pathParts);
     }

--- a/docs/plans/2026-03-09-issue-309-ids-audit.md
+++ b/docs/plans/2026-03-09-issue-309-ids-audit.md
@@ -1,0 +1,32 @@
+## Issue #309 audit
+
+Observed symptom:
+- Reads through `/.ids/<prefix>/<guid>` fail for some mounted workflows with an `input/output error`.
+- The same `DavItem` remains streamable through its normal content path.
+
+Audited code paths:
+- WebDAV `.ids` routing: `backend/WebDav/DatabaseStoreIdsCollection.cs`
+- `.ids` leaf wrapper: `backend/WebDav/DatabaseStoreIdFile.cs`
+- Symlink target generation: `backend/WebDav/DatabaseStoreSymlinkFile.cs`
+- STRM target generation: `backend/Queue/PostProcessors/CreateStrmFilesPostProcessor.cs`
+- STRM-to-symlink migration: `backend/Tasks/StrmToSymlinksTask.cs`
+
+Key finding:
+- The `.ids` path is the only file-serving path that intentionally drops the original filename and extension.
+- Normal content paths expose the real filename, but `.ids` exposes a bare GUID.
+- That changes file metadata seen by WebDAV clients:
+  - `displayname`
+  - MIME inference
+  - any client behavior that keys off the leaf filename/extension
+
+Why this branch changes `.ids` names:
+- It preserves the original extension in generated `.ids` targets and `.ids` listings.
+- It keeps old GUID-only `.ids` paths working by stripping an optional extension during lookup.
+- This is the narrowest backward-compatible change that removes the most obvious `.ids`-specific divergence.
+
+What is still not proven:
+- The repository does not currently contain a reproducible automated test for the exact rclone-mounted failure mode from issue #309.
+- `backend.Tests` also has unrelated compile failures on `main` in `ContentIndexRecoveryServiceTests`, which blocks full test execution for this branch.
+
+Validation completed:
+- `dotnet build backend --no-restore`


### PR DESCRIPTION
## Summary
- preserve the original file extension in generated `/.ids/...` targets for symlink and `.strm` paths
- keep backward compatibility by accepting both legacy GUID-only `/.ids` leaves and the new `GUID.ext` form
- add an audit note describing the code paths reviewed and why this is the most likely `.ids`-specific divergence

## Audit findings
I audited the `/.ids` serving path and compared it with normal content serving:
- `backend/WebDav/DatabaseStoreIdsCollection.cs`
- `backend/WebDav/DatabaseStoreIdFile.cs`
- `backend/WebDav/DatabaseStoreSymlinkFile.cs`
- `backend/Queue/PostProcessors/CreateStrmFilesPostProcessor.cs`
- `backend/Tasks/StrmToSymlinksTask.cs`

The main behavioral difference is that `/.ids` files were exposed as bare GUIDs with no original extension, while normal content paths preserve the real filename. This changes filename-dependent metadata seen by WebDAV clients and mounted filesystems.

This branch removes that divergence while keeping old links working.

## Validation
- `dotnet build backend --no-restore`

## Limitations
- I did not reproduce the exact mounted-rclone failure locally.
- `backend.Tests` on main currently has unrelated compile failures in `ContentIndexRecoveryServiceTests`, so I could not use the repository test project as a clean regression harness for this issue.
- Because of that, this PR should be treated as a targeted fix plus audit rather than a confirmed end-to-end reproduction.

Closes #309