### PR TITLE
fix(ci): exclude docker registry deploy from dependabot

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - '**'
       - '!main'
+      - '!dependabot/**'
 
   workflow_dispatch:
 


### PR DESCRIPTION
Because your pre-release workflow enables you to build container images for testing, and allows non-default branch releases - we should exclude dependabot to prevent tons of automated PR triggered image releases to dockerhub.

If you still want the build process to run for testing dependabot PR's, the step that builds docker images should have a filter excluding it from dependabot.