### PR TITLE
fix: downgrade unreachable Arr instance log from ERR to Debug

### DIFF
--- a/backend/Services/ArrMonitoringService.cs
+++ b/backend/Services/ArrMonitoringService.cs
@@ -52,6 +52,10 @@ public class ArrMonitoringService : BackgroundService
             foreach (var record in stuckRecords)
                 await HandleStuckQueueItem(record, arrConfig, client).ConfigureAwait(false);
         }
+        catch (Exception e) when (e is HttpRequestException { InnerException: System.Net.Sockets.SocketException })
+        {
+            Log.Debug($"Could not reach Arr instance `{client.Host}` for queue monitoring: {e.Message}");
+        }
         catch (Exception e)
         {
             Log.Error($"Error occured while monitoring queue for `{client.Host}`: {e.Message}");


### PR DESCRIPTION
## Problem

`ArrMonitoringService` logs at `ERR` level every 10 seconds for *any* exception when polling a configured Arr instance, including DNS/connection failures:

```
[ERR] Error occured while monitoring queue for `http://sonarranime:8989`: Name does not resolve (sonarranime:8989)
```

This is noisy when Arr instances are pre-configured but not always running (e.g. a host that only exists in some deployments). An unreachable host is not an error — it's an expected transient condition.

## Fix

Catch `HttpRequestException` with an inner `SocketException` (DNS/connection failure) separately and log at `Debug` instead of `ERR`. Genuine unexpected errors still log at `ERR`.

This matches the existing pattern in `QueueItemProcessor.RefreshMonitoredDownloads` which already uses `Log.Debug` for unreachable Arr instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)