### PR TITLE
fix: honour nzbname param in addfile; fix null filename 500 crash

### DIFF
--- a/backend/Api/SabControllers/AddFile/AddFileRequest.cs
+++ b/backend/Api/SabControllers/AddFile/AddFileRequest.cs
@@ -23,9 +23,18 @@ public class AddFileRequest()
             context.Request.Form.Files["name"] ??
             throw new BadHttpRequestException("Invalid nzbFile/name param");
 
+        // prefer nzbname query param (set by some clients), fall back to the form file's filename
+        var nzbName = context.GetQueryParam("nzbname");
+        var fileName = !string.IsNullOrWhiteSpace(nzbName)
+            ? (nzbName.EndsWith(".nzb", StringComparison.OrdinalIgnoreCase) ? nzbName : $"{nzbName}.nzb")
+            : file.FileName;
+
+        if (string.IsNullOrWhiteSpace(fileName))
+            throw new BadHttpRequestException("NZB filename could not be determined.");
+
         return new AddFileRequest()
         {
-            FileName = file.FileName,
+            FileName = fileName,
             MimeType = file.ContentType,
             NzbFileStream = file.OpenReadStream(),
             Category = context.GetQueryParam("cat") ?? configManager.GetManualUploadCategory(),


### PR DESCRIPTION
## Problem

Two related issues with the `addfile` SAB API endpoint:

**1. `nzbname` query parameter is ignored**

`addurl` uses `nzbname` as the primary filename source, but `addfile` ignores it entirely. Some clients (e.g. certain NZB automation tools) send `nzbname=` on `addfile` requests expecting it to set the job name, but only the form file's Content-Disposition filename was used.

**2. Null filename causes a 500 instead of 400**

When the uploaded file has no `filename=` in its Content-Disposition header and `nzbname` is also absent, `file.FileName` is null. This null gets passed to `FilenameUtil.GetJobName` → `PasswordRegex.Match(null)` → `ArgumentNullException: Value cannot be null. (Parameter 'input')` → 500 response.

Example client log showing the pattern:
```
📤 API URL: http://nzbdav:3000/api?mode=addfile&cat=Movies&nzbname=My.Movie.2025.1080p&apikey=***
NZBDav rejected NZB: 500 - {"status":false,"error":"Value cannot be null. (Parameter 'input')"}
```

## Fix

Mirror `addurl` behaviour in `addfile`:
1. Use `nzbname` query param (with `.nzb` extension appended if missing) when present
2. Fall back to `file.FileName`
3. Return a clear 400 `BadHttpRequestException` if neither resolves to a non-empty value

🤖 Generated with [Claude Code](https://claude.com/claude-code)