### PR TITLE
feat: circuit breaker for NNTP provider failover

### DIFF
--- a/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
+++ b/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
@@ -1,0 +1,63 @@
+using System.Collections.Concurrent;
+
+namespace NzbWebDAV.Clients.Usenet.Connections;
+
+/// <summary>
+/// Tracks consecutive connection failures per provider and temporarily
+/// "opens" the circuit (skips the provider) after a threshold is reached.
+/// Resets automatically after a cooldown period.
+/// </summary>
+public class ProviderCircuitBreaker
+{
+    private readonly int _failureThreshold;
+    private readonly TimeSpan _cooldown;
+    private readonly ConcurrentDictionary<int, ProviderState> _states = new();
+
+    public ProviderCircuitBreaker(int failureThreshold = 3, TimeSpan? cooldown = null)
+    {
+        _failureThreshold = failureThreshold;
+        _cooldown = cooldown ?? TimeSpan.FromSeconds(30);
+    }
+
+    /// <summary>
+    /// Returns true if the provider should be skipped (circuit is open).
+    /// </summary>
+    public bool IsOpen(int providerIndex)
+    {
+        if (!_states.TryGetValue(providerIndex, out var state))
+            return false;
+
+        if (state.ConsecutiveFailures < _failureThreshold)
+            return false;
+
+        // If cooldown has elapsed, allow a probe attempt
+        if (Environment.TickCount64 - state.LastFailureTickMs >= _cooldown.TotalMilliseconds)
+            return false;
+
+        return true;
+    }
+
+    public void RecordFailure(int providerIndex)
+    {
+        _states.AddOrUpdate(
+            providerIndex,
+            _ => new ProviderState { ConsecutiveFailures = 1, LastFailureTickMs = Environment.TickCount64 },
+            (_, existing) =>
+            {
+                existing.ConsecutiveFailures++;
+                existing.LastFailureTickMs = Environment.TickCount64;
+                return existing;
+            });
+    }
+
+    public void RecordSuccess(int providerIndex)
+    {
+        _states.TryRemove(providerIndex, out _);
+    }
+
+    private class ProviderState
+    {
+        public int ConsecutiveFailures;
+        public long LastFailureTickMs;
+    }
+}

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.ExceptionServices;
+using NzbWebDAV.Clients.Usenet.Connections;
 using NzbWebDAV.Clients.Usenet.Models;
 using NzbWebDAV.Extensions;
 using NzbWebDAV.Models;
@@ -9,6 +10,7 @@ namespace NzbWebDAV.Clients.Usenet;
 
 public class MultiProviderNntpClient(List<MultiConnectionNntpClient> providers) : NntpClient
 {
+    private readonly ProviderCircuitBreaker _circuitBreaker = new();
     public override Task ConnectAsync(string host, int port, bool useSsl, CancellationToken ct)
     {
         throw new NotSupportedException("Please connect within the connectionFactory");
@@ -126,31 +128,56 @@ public class MultiProviderNntpClient(List<MultiConnectionNntpClient> providers) 
     {
         ExceptionDispatchInfo? lastException = null;
         var orderedProviders = GetOrderedProviders();
-        for (var i = 0; i < orderedProviders.Count; i++)
+
+        // First pass: skip circuit-broken providers
+        // Second pass (fallback): include circuit-broken providers so we never give up entirely
+        for (var pass = 0; pass < 2; pass++)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            var provider = orderedProviders[i];
-            var isLastProvider = i == orderedProviders.Count - 1;
-
-            if (lastException is not null)
+            for (var i = 0; i < orderedProviders.Count; i++)
             {
-                var msg = lastException.SourceException.Message;
-                Log.Debug($"Encountered error during NNTP Operation: `{msg}`. Trying another provider.");
-            }
+                cancellationToken.ThrowIfCancellationRequested();
+                var (provider, providerIndex) = orderedProviders[i];
+                var isLastProviderInLastPass = pass == 1 && i == orderedProviders.Count - 1;
 
-            try
-            {
-                var result = await task.Invoke(provider).ConfigureAwait(false);
-
-                // if no article with that message-id is found, try again with the next provider.
-                if (!isLastProvider && result.ResponseType == UsenetResponseType.NoArticleWithThatMessageId)
+                // First pass: skip providers with open circuits
+                if (pass == 0 && _circuitBreaker.IsOpen(providerIndex))
+                {
+                    Log.Debug("Skipping provider {ProviderIndex} (circuit breaker open).", providerIndex);
                     continue;
+                }
 
-                return result;
+                if (lastException is not null)
+                {
+                    var msg = lastException.SourceException.Message;
+                    Log.Debug($"Encountered error during NNTP Operation: `{msg}`. Trying another provider.");
+                }
+
+                try
+                {
+                    var result = await task.Invoke(provider).ConfigureAwait(false);
+
+                    _circuitBreaker.RecordSuccess(providerIndex);
+
+                    // if no article with that message-id is found, try again with the next provider.
+                    if (!isLastProviderInLastPass &&
+                        result.ResponseType == UsenetResponseType.NoArticleWithThatMessageId)
+                        continue;
+
+                    return result;
+                }
+                catch (Exception e) when (!e.IsCancellationException())
+                {
+                    _circuitBreaker.RecordFailure(providerIndex);
+                    lastException = ExceptionDispatchInfo.Capture(e);
+                }
             }
-            catch (Exception e) when (!e.IsCancellationException())
+
+            if (pass == 0)
             {
-                lastException = ExceptionDispatchInfo.Capture(e);
+                // Check if any providers were skipped — if not, no point in second pass
+                var anySkipped = orderedProviders.Any(p => _circuitBreaker.IsOpen(p.ProviderIndex));
+                if (!anySkipped)
+                    break;
             }
         }
 
@@ -158,12 +185,13 @@ public class MultiProviderNntpClient(List<MultiConnectionNntpClient> providers) 
         throw new Exception("There are no usenet providers configured.");
     }
 
-    private List<MultiConnectionNntpClient> GetOrderedProviders()
+    private List<(MultiConnectionNntpClient Provider, int ProviderIndex)> GetOrderedProviders()
     {
         return providers
-            .Where(x => x.ProviderType != ProviderType.Disabled)
-            .OrderBy(x => x.ProviderType)
-            .ThenByDescending(x => x.AvailableConnections)
+            .Select((provider, index) => (Provider: provider, ProviderIndex: index))
+            .Where(x => x.Provider.ProviderType != ProviderType.Disabled)
+            .OrderBy(x => x.Provider.ProviderType)
+            .ThenByDescending(x => x.Provider.AvailableConnections)
             .ToList();
     }
 


### PR DESCRIPTION
## Summary

When multiple providers are configured and some are unreachable (connection refused, SSL handshake failure, auth error), every segment request currently tries all providers sequentially — including broken ones. Each broken provider incurs 2 TCP/SSL timeout waits (the retry in `MultiConnectionNntpClient`) before falling through. With many concurrent segment requests, this causes massive latency and streaming failures even though a working provider exists.

This PR adds a lightweight circuit breaker to `MultiProviderNntpClient`:

- After **3 consecutive failures**, a provider is temporarily skipped for **30 seconds**
- Requests go directly to healthy providers instead of waiting for timeouts on broken ones
- After the cooldown, a single probe request checks if the provider has recovered
- One success resets the circuit immediately
- **Safety net**: if all healthy providers also fail, a second pass retries circuit-broken providers — we never silently give up on a request

## Changes

- **New file**: `ProviderCircuitBreaker.cs` (~60 lines) — tracks consecutive failures and cooldown per provider index, using `ConcurrentDictionary` for thread safety
- **Modified**: `MultiProviderNntpClient.cs` — wraps the existing provider loop in a two-pass structure (skip broken → fallback to all), records success/failure per provider

## What stays the same

- No new configuration, env vars, or dependencies
- Provider ordering logic (ProviderType + available connections) unchanged
- Per-connection retry logic in `MultiConnectionNntpClient` unchanged
- All existing behavior preserved when no providers are failing

## Test plan

- [ ] 3 pooled providers, 2 unreachable: streaming should work via the 1 healthy provider without multi-second delays per segment
- [ ] All providers healthy: no change in behavior
- [ ] Provider recovers after outage: circuit closes after cooldown + successful probe
- [ ] All providers broken: requests still fail (as before), no silent drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)