### PR TITLE
fix: gate STAT/HEAD through PrioritizedSemaphore for effective streaming priority

### DIFF
--- a/backend/Clients/Usenet/DownloadingNntpClient.cs
+++ b/backend/Clients/Usenet/DownloadingNntpClient.cs
@@ -8,8 +8,9 @@ using UsenetSharp.Models;
 namespace NzbWebDAV.Clients.Usenet;
 
 /// <summary>
-/// This client is only responsible for limiting download operations (BODY/ARTICLE)
-/// to the configured number of maximum download connections.
+/// This client is responsible for limiting NNTP operations (STAT/HEAD/BODY/ARTICLE)
+/// to the configured number of maximum download connections, with priority-based
+/// scheduling that favors streaming over queue operations.
 /// </summary>
 /// <param name="usenetClient"></param>
 public class DownloadingNntpClient : WrappingNntpClient
@@ -38,6 +39,39 @@ public class DownloadingNntpClient : WrappingNntpClient
         {
             var streamingPriority = _configManager.GetStreamingPriority();
             _semaphore.UpdatePriorityOdds(streamingPriority);
+        }
+    }
+
+    /// <summary>
+    /// Gate STAT/HEAD through the PrioritizedSemaphore so that queue operations
+    /// (which perform many STATs for InterpolationSearch, PAR2 parsing, etc.)
+    /// cannot monopolize all ConnectionPool connections and starve streaming.
+    /// Without this, 55 concurrent queue items doing STAT operations bypass the
+    /// semaphore and consume all connections, making streaming-priority ineffective.
+    /// </summary>
+    public override async Task<UsenetStatResponse> StatAsync(SegmentId segmentId, CancellationToken cancellationToken)
+    {
+        await AcquireExclusiveConnectionAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return await base.StatAsync(segmentId, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    public override async Task<UsenetHeadResponse> HeadAsync(SegmentId segmentId, CancellationToken cancellationToken)
+    {
+        await AcquireExclusiveConnectionAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return await base.HeadAsync(segmentId, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _semaphore.Release();
         }
     }
 


### PR DESCRIPTION
## Problem

When the NzbDAV queue has many items (500+), streaming playback stutters or fails entirely. The `streaming-priority` config setting has no practical effect under heavy queue load.

**Root cause:** Queue processing runs up to 55 concurrent items (`WithConcurrencyAsync(maxDownloadConnections + 5)`). Each item performs multiple STAT/HEAD operations for InterpolationSearch, PAR2 parsing, and article existence checks. These STAT/HEAD operations go directly to the ConnectionPool — they bypass the `PrioritizedSemaphore` in `DownloadingNntpClient`.

With 55 concurrent items each doing STAT operations, all ConnectionPool connections are monopolized by queue operations. When a streaming BODY request gets a high-priority semaphore permit, it still can't get a ConnectionPool connection because they're all busy with queue STATs.

The `PrioritizedSemaphore` was designed to give streaming requests priority, but it only gates BODY/ARTICLE commands. STAT/HEAD commands bypass it entirely, making the priority mechanism ineffective.

## Fix

Override `StatAsync` and `HeadAsync` in `DownloadingNntpClient` to acquire a semaphore permit before executing. Queue STAT/HEAD operations now get `SemaphorePriority.Low` (via `DownloadPriorityContext`), while streaming operations get `SemaphorePriority.High`.

All NNTP operations (STAT, HEAD, BODY, ARTICLE) now go through the same prioritized semaphore. When streaming is active, it gets priority based on the `streaming-priority` config. Queue operations — including STATs — get the remainder.

STAT/HEAD operations are lightweight (~10ms round-trip), so permits are released quickly and don't hold up the pipeline.

## Results

Tested with a 5000-item queue on Eweka (50 connections, 600 Mbit/s line):

| Scenario | Before | After |
|----------|--------|-------|
| Queue alone | 600 Mbit/s | 600 Mbit/s (unchanged) |
| Streaming alone | ~400 Mbit/s | ~400 Mbit/s (unchanged) |
| Streaming during queue | 0-5 Mbit/s | ~400 Mbit/s |

No impact on queue throughput when streaming is inactive. `streaming-priority` config now works as intended.

## Related Issues

- Fixes #221 — NzbDAV slows down with 500+ items in queue
- Fixes #148 — Streaming/Playback limited to 1 active connection