### PR TITLE
fix(nntp): Skip failing usenet providers with circuit breaker

### DIFF
--- a/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
+++ b/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
@@ -1,0 +1,82 @@
+using Serilog;
+
+namespace NzbWebDAV.Clients.Usenet.Connections;
+
+/// <summary>
+/// Tracks consecutive connection failures for an NNTP provider and temporarily
+/// disables it when a failure threshold is reached, preventing a single
+/// misbehaving provider from blocking the entire download pipeline.
+/// <para>
+/// After tripping, the provider enters a cooldown period during which it is
+/// skipped. When the cooldown expires, a single probe attempt is allowed.
+/// If the probe succeeds, the breaker resets. If it fails, the cooldown
+/// doubles (up to a cap) and the breaker re-trips.
+/// </para>
+/// </summary>
+public class ProviderCircuitBreaker
+{
+    private const int FailureThreshold = 3;
+    private static readonly TimeSpan InitialCooldown = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan MaxCooldown = TimeSpan.FromMinutes(5);
+
+    private readonly string _providerName;
+    private readonly object _lock = new();
+
+    private int _consecutiveFailures;
+    private long _trippedUntilMs;
+    private TimeSpan _currentCooldown = InitialCooldown;
+
+    public ProviderCircuitBreaker(string providerName)
+    {
+        _providerName = providerName;
+    }
+
+    public bool IsTripped
+    {
+        get
+        {
+            lock (_lock)
+            {
+                if (_trippedUntilMs == 0) return false;
+                if (Environment.TickCount64 >= _trippedUntilMs)
+                {
+                    // Cooldown expired — allow a probe attempt
+                    return false;
+                }
+                return true;
+            }
+        }
+    }
+
+    public void RecordSuccess()
+    {
+        lock (_lock)
+        {
+            if (_consecutiveFailures > 0 || _trippedUntilMs > 0)
+                Log.Information("Provider {Provider} recovered — circuit breaker reset.", _providerName);
+
+            _consecutiveFailures = 0;
+            _trippedUntilMs = 0;
+            _currentCooldown = InitialCooldown;
+        }
+    }
+
+    public void RecordFailure()
+    {
+        lock (_lock)
+        {
+            _consecutiveFailures++;
+
+            if (_consecutiveFailures < FailureThreshold) return;
+
+            _trippedUntilMs = Environment.TickCount64 + (long)_currentCooldown.TotalMilliseconds;
+            Log.Warning(
+                "Provider {Provider} tripped after {Failures} consecutive failures. " +
+                "Skipping for {Cooldown}s.",
+                _providerName, _consecutiveFailures, _currentCooldown.TotalSeconds);
+
+            _currentCooldown = TimeSpan.FromMilliseconds(
+                Math.Min(_currentCooldown.TotalMilliseconds * 2, MaxCooldown.TotalMilliseconds));
+        }
+    }
+}

--- a/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
+++ b/backend/Clients/Usenet/Connections/ProviderCircuitBreaker.cs
@@ -35,16 +35,9 @@ public class ProviderCircuitBreaker
     {
         get
         {
-            lock (_lock)
-            {
-                if (_trippedUntilMs == 0) return false;
-                if (Environment.TickCount64 >= _trippedUntilMs)
-                {
-                    // Cooldown expired — allow a probe attempt
-                    return false;
-                }
-                return true;
-            }
+            var trippedUntil = Volatile.Read(ref _trippedUntilMs);
+            if (trippedUntil == 0) return false;
+            return Environment.TickCount64 < trippedUntil;
         }
     }
 

--- a/backend/Clients/Usenet/MultiConnectionNntpClient.cs
+++ b/backend/Clients/Usenet/MultiConnectionNntpClient.cs
@@ -20,10 +20,16 @@ namespace NzbWebDAV.Clients.Usenet;
 /// </summary>
 /// <param name="connectionPool"></param>
 /// <param name="type"></param>
+/// <param name="circuitBreaker"></param>
 [SuppressMessage("ReSharper", "AccessToDisposedClosure")]
-public class MultiConnectionNntpClient(ConnectionPool<INntpClient> connectionPool, ProviderType type) : NntpClient
+public class MultiConnectionNntpClient(
+    ConnectionPool<INntpClient> connectionPool,
+    ProviderType type,
+    ProviderCircuitBreaker circuitBreaker
+) : NntpClient
 {
     public ProviderType ProviderType { get; } = type;
+    public bool IsTripped => circuitBreaker.IsTripped;
     public int LiveConnections => connectionPool.LiveConnections;
     public int IdleConnections => connectionPool.IdleConnections;
     public int ActiveConnections => connectionPool.ActiveConnections;
@@ -156,6 +162,7 @@ public class MultiConnectionNntpClient(ConnectionPool<INntpClient> connectionPoo
             }
             catch (Exception e)
             {
+                circuitBreaker.RecordFailure();
                 LogException(() => connectionLock?.Replace());
                 LogException(() => connectionLock?.Dispose());
                 if (retryCount > 0)
@@ -189,6 +196,7 @@ public class MultiConnectionNntpClient(ConnectionPool<INntpClient> connectionPoo
             }
             catch (Exception e)
             {
+                circuitBreaker.RecordFailure();
                 LogException(() => connectionLock?.Replace());
                 LogException(() => connectionLock?.Dispose());
                 if (retryCount > 0)
@@ -202,6 +210,8 @@ public class MultiConnectionNntpClient(ConnectionPool<INntpClient> connectionPoo
                 LogException(() => onConnectionReadyAgain?.Invoke(ArticleBodyResult.NotRetrieved));
                 throw;
             }
+
+            circuitBreaker.RecordSuccess();
 
             // stat, head, and date
             if (name is "STAT" or "HEAD" or "DATE")

--- a/backend/Clients/Usenet/MultiProviderNntpClient.cs
+++ b/backend/Clients/Usenet/MultiProviderNntpClient.cs
@@ -160,11 +160,16 @@ public class MultiProviderNntpClient(List<MultiConnectionNntpClient> providers) 
 
     private List<MultiConnectionNntpClient> GetOrderedProviders()
     {
-        return providers
+        var enabled = providers
             .Where(x => x.ProviderType != ProviderType.Disabled)
             .OrderBy(x => x.ProviderType)
             .ThenByDescending(x => x.AvailableConnections)
             .ToList();
+
+        var healthy = enabled.Where(x => !x.IsTripped).ToList();
+
+        // Always return at least one provider so cooldown probes can fire.
+        return healthy.Count > 0 ? healthy : enabled;
     }
 
     public override void Dispose()

--- a/backend/Clients/Usenet/UsenetStreamingClient.cs
+++ b/backend/Clients/Usenet/UsenetStreamingClient.cs
@@ -59,7 +59,8 @@ public class UsenetStreamingClient : WrappingNntpClient
             connectionFactory: ct => CreateNewConnection(connectionDetails, ct),
             onConnectionPoolChanged
         );
-        return new MultiConnectionNntpClient(connectionPool, connectionDetails.Type);
+        var circuitBreaker = new ProviderCircuitBreaker(connectionDetails.Host);
+        return new MultiConnectionNntpClient(connectionPool, connectionDetails.Type, circuitBreaker);
     }
 
     private static ConnectionPool<INntpClient> CreateNewConnectionPool


### PR DESCRIPTION
## Skip failing usenet providers with circuit breaker

### Problem

When a usenet provider fails to authenticate (e.g. changed password, expired account, provider outage), every NNTP operation still attempts that provider first. Each failed attempt burns ~40 seconds waiting for UsenetSharp's internal read timeout, and with 1 retry that's ~80 seconds wasted per segment before falling through to the next provider.

For downloads with hundreds of segments, this means the download stalls at 0% and gets re-queued endlessly - even though other healthy providers are available and could serve the content. This affects both pooled and backup providers equally: one misbehaving provider brings the entire pipeline down.

### Solution

Add a `ProviderCircuitBreaker` to each provider that tracks consecutive connection failures and temporarily removes the provider from the rotation when a failure threshold is reached.

**Circuit breaker behavior:**
- **Threshold:** 3 consecutive failures to trip
- **Initial cooldown:** 60 seconds (doubles on repeated trips, capped at 5 minutes)
- **Probe:** after cooldown expires, one attempt is allowed - success resets the breaker, failure re-trips with longer cooldown
- **Logging:** warns when a provider trips, logs when it recovers

`MultiProviderNntpClient.GetOrderedProviders()` now filters out tripped providers, so healthy providers handle traffic immediately. If all providers are tripped, the full list is returned so cooldown probes can still fire.

### Changes

- **New:** `ProviderCircuitBreaker` - tracks consecutive failures, manages trip/cooldown/probe lifecycle
- **Modified:** `MultiConnectionNntpClient` - records success/failure on the circuit breaker after each operation
- **Modified:** `MultiProviderNntpClient` - skips tripped providers in `GetOrderedProviders()`
- **Modified:** `UsenetStreamingClient` - creates a `ProviderCircuitBreaker` per provider (identified by host name)

Fixes #282 