### PR TITLE
feat: add LISTEN_ADDRESS env var to configure bind interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,10 +48,14 @@ COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # Set env variables
-EXPOSE 3000
+# Port 3000: frontend  Port 8080: backend (WebDAV / API)
+EXPOSE 3000 8080
 ARG NZBDAV_VERSION
 ENV NZBDAV_VERSION=${NZBDAV_VERSION}
 ENV NODE_ENV=production
 ENV LOG_LEVEL=warning
+# LISTEN_ADDRESS controls the network interface both the frontend and backend bind to.
+# Default is 0.0.0.0 (all interfaces). Set to a specific IP to restrict binding.
+ENV LISTEN_ADDRESS=0.0.0.0
 
 CMD ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,9 +64,22 @@ else
     USER_NAME=appuser
 fi
 
-# Set environment variables
+# Configure the listen address.
+# Defaults to 0.0.0.0 (all interfaces), preserving the existing behaviour.
+# Set LISTEN_ADDRESS to a specific IP (e.g. 192.168.1.10) to restrict which
+# network interface nzbdav binds to.
+LISTEN_ADDRESS=${LISTEN_ADDRESS:-0.0.0.0}
+export ASPNETCORE_URLS="http://${LISTEN_ADDRESS}:8080"
+
+# BACKEND_URL is used internally by the frontend to proxy requests to the backend.
+# When LISTEN_ADDRESS is a wildcard/loopback address localhost is always reachable.
+# When LISTEN_ADDRESS is a specific non-loopback IP, derive BACKEND_URL from it.
 if [ -z "${BACKEND_URL}" ]; then
-    export BACKEND_URL="http://localhost:8080"
+    if [ "$LISTEN_ADDRESS" = "0.0.0.0" ] || [ "$LISTEN_ADDRESS" = "127.0.0.1" ] || [ "$LISTEN_ADDRESS" = "localhost" ] || [ "$LISTEN_ADDRESS" = "::" ] || [ "$LISTEN_ADDRESS" = "::1" ]; then
+        export BACKEND_URL="http://localhost:8080"
+    else
+        export BACKEND_URL="http://${LISTEN_ADDRESS}:8080"
+    fi
 fi
 
 if [ -z "${FRONTEND_BACKEND_API_KEY}" ]; then

--- a/frontend/server.ts
+++ b/frontend/server.ts
@@ -8,6 +8,7 @@ import { WebSocketServer } from "ws";
 const BUILD_PATH = "../build/server/index.js";
 const DEVELOPMENT = process.env.NODE_ENV === "development";
 const PORT = Number.parseInt(process.env.PORT || "3000");
+const HOST = process.env.LISTEN_ADDRESS || "0.0.0.0";
 
 // Initialize the express app
 const app = express();
@@ -90,6 +91,6 @@ const server = http.createServer(app);
 setWebsocketServer(new WebSocketServer({ server }));
 
 // Begin listening for connections
-server.listen(PORT, () => {
-  console.log(`Server is running on http://localhost:${PORT}`);
+server.listen(PORT, HOST, () => {
+  console.log(`Server is running on http://${HOST}:${PORT}`);
 });


### PR DESCRIPTION
## Summary

Closes #408

Adds a `LISTEN_ADDRESS` environment variable so users can control which network interface nzbdav binds to. This is particularly useful when running in host-network mode with multiple NICs and you want to restrict nzbdav to a specific interface.

## Behaviour

| `LISTEN_ADDRESS` | Result |
|---|---|
| `0.0.0.0` (default) | Binds all interfaces — identical to current behaviour |
| `192.168.1.10` | Binds only that specific IP |
| `127.0.0.1` | Loopback only |

## Changes

### `entrypoint.sh`
- Reads `LISTEN_ADDRESS` (defaults to `0.0.0.0` to preserve existing behaviour)
- Sets `ASPNETCORE_URLS=http://${LISTEN_ADDRESS}:8080` so Kestrel honours it
- Derives `BACKEND_URL` from `LISTEN_ADDRESS` when it is a specific non-wildcard, non-loopback IP (otherwise keeps `http://localhost:8080` so the internal proxy still works)

### `frontend/server.ts`
- Reads `LISTEN_ADDRESS` and passes it as the host argument to `server.listen()` so the Node.js frontend binds to the same interface

### `Dockerfile`
- Adds `ENV LISTEN_ADDRESS=0.0.0.0` to document the variable
- Exposes port `8080` alongside the existing `3000`

## Example

```sh
# Restrict to a single NIC
docker run -e LISTEN_ADDRESS=192.168.1.10 -p 3000:3000 -p 8080:8080 nzbdav/nzbdav:latest
```